### PR TITLE
Fix storage offer deadlock by sending async gossip

### DIFF
--- a/src/p2p/user_node.rs
+++ b/src/p2p/user_node.rs
@@ -212,7 +212,7 @@ impl UserNode {
                 "reply_addr": [self.host, self.port],
             }
         });
-        let _ = super::node::send_json_line(self.bootstrap_addr, &offer);
+        let _ = super::node::send_json_line_without_response(self.bootstrap_addr, &offer);
         log_msg(
             "INFO",
             "USER_NODE",


### PR DESCRIPTION
## Summary
- avoid blocking the gossip path by sending storage bids and gossip messages asynchronously
- add a helper for fire-and-forget messaging and apply it to user nodes when broadcasting storage offers

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68ca9bf623808327930f12846eab2916