### PR TITLE
Handle user communications asynchronously with broadcast buffer

### DIFF
--- a/src/p2p/node.rs
+++ b/src/p2p/node.rs
@@ -1510,14 +1510,18 @@ impl Node {
                                 .unwrap_or(Value::Null),
                         }
                     });
-                    if send_json_line(addr, &payload).is_none() {
-                        log_msg(
-                            "WARN",
-                            "P2P_NET",
-                            Some(self.node_id.clone()),
-                            &format!("向文件所有者发送文件 {} 最终证明失败", fid),
-                        );
-                    }
+                    let node_id = self.node_id.clone();
+                    let file_id = fid.clone();
+                    thread::spawn(move || {
+                        if send_json_line(addr, &payload).is_none() {
+                            log_msg(
+                                "WARN",
+                                "P2P_NET",
+                                Some(node_id),
+                                &format!("向文件所有者发送文件 {} 最终证明失败", file_id),
+                            );
+                        }
+                    });
                 }
             }
         }


### PR DESCRIPTION
## Summary
- add a shared broadcast buffer to the user node so incoming network commands are queued and drained outside of the networking threads
- update the final proof listener and response handling to enqueue proofs and acknowledge them asynchronously
- send final proof messages from miners to file owners on a detached thread so consensus work is not blocked waiting on acknowledgements

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68d0cd76c1308327af5f4855ffa78e75