### PR TITLE
Select earliest timestamp block per height

### DIFF
--- a/src/p2p/node.rs
+++ b/src/p2p/node.rs
@@ -865,11 +865,24 @@ impl Node {
     fn process_new_block_buffer(&mut self) {
         loop {
             let expected_height = self.chain.height() + 1;
-            let Some(pos) = self
-                .new_block_buffer
-                .iter()
-                .position(|block| block.height as usize == expected_height)
-            else {
+            let mut candidate_pos: Option<usize> = None;
+            let mut best_timestamp: Option<u128> = None;
+
+            for (idx, block) in self.new_block_buffer.iter().enumerate() {
+                if block.height as usize != expected_height {
+                    continue;
+                }
+
+                match best_timestamp {
+                    Some(ts) if block.timestamp >= ts => {}
+                    _ => {
+                        best_timestamp = Some(block.timestamp);
+                        candidate_pos = Some(idx);
+                    }
+                }
+            }
+
+            let Some(pos) = candidate_pos else {
                 break;
             };
 


### PR DESCRIPTION
## Summary
- ensure the node chooses the earliest timestamped block when processing buffered blocks for a height
- retain existing logging for invalid candidates while discarding later forks

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d11009019483279b8fd57c8821a514