### PR TITLE
Restrict mining to complete files

### DIFF
--- a/src/storage/state.rs
+++ b/src/storage/state.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use serde::{Deserialize, Serialize};
 
@@ -98,12 +98,17 @@ impl ServerStorage {
             .insert(index, commitment);
     }
 
-    pub fn build_state(&mut self) {
+    pub fn build_state(&mut self, include_only: Option<&HashSet<String>>) {
         for tst in self.time_trees.values_mut() {
             tst.build();
         }
         let mut file_roots = HashMap::new();
         for (fid, tst) in &self.time_trees {
+            if let Some(filter) = include_only {
+                if !filter.contains(fid) {
+                    continue;
+                }
+            }
             file_roots.insert(fid.clone(), tst.root());
         }
         let mut storage_tree = StorageStateTree {


### PR DESCRIPTION
## Summary
- track which stored files have received all expected chunks before treating them as complete
- build storage state trees and file root lists using only the completed files so mining excludes incomplete data
- update mining metadata such as file counts to rely on the completed-file set

## Testing
- cargo test


------
https://chatgpt.com/codex/tasks/task_e_68d24f1c1ca08327875e264339fc8ca2