### PR TITLE
Clean project structure and document core modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -96,7 +96,7 @@ checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -245,35 +245,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.9.4",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "log",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.106",
- "which",
-]
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
 name = "bitflags"
 version = "2.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -324,8 +295,6 @@ dependencies = [
  "env_logger",
  "ff",
  "hex",
- "icicle-core",
- "icicle-cuda-runtime",
  "indexmap",
  "light-poseidon",
  "log",
@@ -366,15 +335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,17 +351,6 @@ dependencies = [
  "num-traits",
  "wasm-bindgen",
  "windows-link 0.2.0",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -548,16 +497,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
-name = "errno"
-version = "0.3.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
-dependencies = [
- "libc",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "ff"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -636,12 +575,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,15 +647,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "home"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
-dependencies = [
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "iana-time-zone"
 version = "0.1.64"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -747,25 +671,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "icicle-core"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ac228a839d456a5fd9dfcde0b6f580bd74dda9b63d6f4768d479de7e633fd6c"
-dependencies = [
- "icicle-cuda-runtime",
-]
-
-[[package]]
-name = "icicle-cuda-runtime"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bd20723c55b33be2c88024178c6773b9f6775ddb71e72072f41c2fd8380afc4"
-dependencies = [
- "bindgen",
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -782,15 +687,6 @@ name = "is_terminal_polyfill"
 version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
-
-[[package]]
-name = "itertools"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -866,26 +762,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
-
-[[package]]
-name = "libloading"
-version = "0.8.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
-dependencies = [
- "cfg-if",
- "windows-targets 0.53.3",
-]
 
 [[package]]
 name = "light-poseidon"
@@ -898,12 +778,6 @@ dependencies = [
  "num-bigint 0.4.6",
  "thiserror 1.0.69",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "lock_api"
@@ -926,22 +800,6 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
-]
 
 [[package]]
 name = "nova-snark"
@@ -1087,16 +945,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn 2.0.106",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.101"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,7 +1024,7 @@ version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
- "bitflags 2.9.4",
+ "bitflags",
 ]
 
 [[package]]
@@ -1207,25 +1055,6 @@ name = "regex-syntax"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caf4aa5b0f434c91fe5c7f1ecb6a5ece2130b02ad2a590589dda5146df959001"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.9.4",
- "errno",
- "libc",
- "linux-raw-sys",
- "windows-sys 0.59.0",
-]
 
 [[package]]
 name = "rustversion"
@@ -1520,18 +1349,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
-]
-
-[[package]]
 name = "windows-core"
 version = "0.62.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1594,15 +1411,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7218c655a553b0bed4426cf54b20d7ba363ef543b52d515b3e48d7fd55318dda"
 dependencies = [
  "windows-link 0.2.0",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,11 +31,5 @@ nova-snark = "0.41"
 bincode = "1.3"
 ff = "0.13"
 
-# 可选的 GPU 加速依赖（默认不启用，启用时仍会安全回退）
-icicle-core = { version = "1.3", optional = true }
-icicle-cuda-runtime = { version = "1.3", optional = true }
-
 [features]
 default = []
-# 预留 GPU 特性开关（当前实现会在不可用时回退到 CPU 并行）
-gpu-icicle = ["icicle-core", "icicle-cuda-runtime"]

--- a/src/common/datastructures.rs
+++ b/src/common/datastructures.rs
@@ -7,25 +7,38 @@ use serde_json::Value;
 
 use crate::utils::h_join;
 
+/// 链上共识与存储子系统共享的数据结构定义。
+///
+/// 这些类型在多个模块之间频繁传递，因此集中在一个文件中便于统一维护和添加文档。
+/// 证明摘要，用于在区块中引用节点提交的 Bobtail 证明。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProofSummary {
+    /// 证明提交节点的身份标识。
     pub node_id: String,
+    /// 证明的 Poseidon 哈希值。
     pub proof_hash: String,
 }
 
+/// 单个挑战条目，包含被挑战的块索引以及挑战系数。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChallengeEntry(pub usize, pub String);
 
+/// 区块主体，记录在一个出块周期内收集到的证明与挑战信息。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BlockBody {
+    /// 领导者选择出的 `k` 个最优 Bobtail 证明。
     #[serde(default)]
     pub selected_k_proofs: Vec<ProofSummary>,
+    /// 奖励拆分信息，`account -> amount`。
     #[serde(default)]
     pub coinbase_splits: HashMap<String, String>,
+    /// Bobtail 证明集合的 Merkle 树（节点 -> 子节点列表）。
     #[serde(default)]
     pub proofs_merkle_tree: IndexMap<String, Vec<String>>,
+    /// dPDP 挑战集合，`file_id -> round -> challenge entries`。
     #[serde(default)]
     pub dpdp_challenges: HashMap<String, HashMap<String, Vec<ChallengeEntry>>>,
+    /// dPDP 证明集合，结构与挑战相似。
     #[serde(default)]
     pub dpdp_proofs: HashMap<String, HashMap<String, Value>>,
 }
@@ -42,24 +55,38 @@ impl Default for BlockBody {
     }
 }
 
+/// 区块头与主体的组合，代表链上的一块数据。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Block {
+    /// 当前区块高度。
     pub height: u64,
+    /// 父区块哈希。
     pub prev_hash: String,
+    /// Bobtail 随机数种子。
     pub seed: String,
+    /// 本轮领导者节点标识。
     pub leader_id: String,
+    /// 累计折叠证明的哈希。
     pub accum_proof_hash: String,
+    /// 各类 Merkle 树的根。
     pub merkle_roots: HashMap<String, String>,
+    /// 折叠证明语句的哈希。
     pub round_proof_stmt_hash: String,
+    /// 区块主体。
     pub body: BlockBody,
+    /// 时间状态树根，按文件划分。
     #[serde(default)]
     pub time_tree_roots: HashMap<String, HashMap<String, String>>,
+    /// Bobtail 算法参数 `k`。
     pub bobtail_k: u64,
+    /// 目标难度。
     pub bobtail_target: String,
+    /// 区块时间戳。
     pub timestamp: u128,
 }
 
 impl Block {
+    /// 生成区块头部哈希，作为区块在网络中的唯一标识。
     pub fn header_hash(&self) -> String {
         let mut merkle_parts: Vec<String> = self
             .merkle_roots
@@ -84,50 +111,79 @@ impl Block {
     }
 }
 
+/// 单个数据块及其 dPDP 标签，用户节点会将其分发给存储节点。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FileChunk {
+    /// 数据块在文件中的索引。
     pub index: usize,
+    /// 原始数据内容。
     #[serde(with = "serde_bytes")]
     pub data: Vec<u8>,
+    /// dPDP 认证标签。
     #[serde(with = "serde_bytes")]
     pub tag: Vec<u8>,
+    /// 所属文件的标识。
     pub file_id: String,
 }
 
+/// Bobtail 共识中节点提交的证明。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct BobtailProof {
+    /// 证明提交者节点 ID。
     pub node_id: String,
+    /// 节点的网络地址。
     pub address: String,
+    /// 当前挖矿窗口的 Merkle 根。
     pub root: String,
+    /// 随机数 nonce。
     pub nonce: String,
+    /// 证明哈希，用于快速比较。
     pub proof_hash: String,
+    /// Bobtail “票数”字段。
     pub lots: String,
+    /// （可选）附带的文件 Merkle 根。
     #[serde(default)]
     pub file_roots: HashMap<String, String>,
 }
 
+/// dPDP 所需的公开参数与私钥。
 #[derive(Debug, Clone)]
 pub struct DPDPParams {
+    /// 群生成元 `g`（G2）。
     pub g: ark_bn254::G2Projective,
+    /// 群生成元 `u`（G1）。
     pub u: ark_bn254::G1Projective,
+    /// 公钥 `β`。
     pub pk_beta: ark_bn254::G2Projective,
+    /// 私钥 `α`。
     pub sk_alpha: BigUint,
 }
 
+/// 文件的 dPDP 标签集合。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DPDPTags {
+    /// 每个数据块对应的签名标签。
     pub tags: Vec<Vec<u8>>,
 }
 
 impl DPDPTags {
+    /// 标签数量，即文件块数量。
     pub fn len(&self) -> usize {
         self.tags.len()
     }
+
+    /// 判断是否为空文件。
+    pub fn is_empty(&self) -> bool {
+        self.tags.is_empty()
+    }
 }
 
+/// 聚合后的 dPDP 响应，由存储节点返回给验证者。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DPDPProof {
+    /// 挑战权重的线性组合结果。
     pub mu: String,
+    /// 聚合后的签名。
     #[serde(with = "serde_bytes")]
     pub sigma: Vec<u8>,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+/// 控制 P2P 模拟行为的一组参数。
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct P2PSimConfig {
     pub num_nodes: usize,
@@ -20,6 +21,7 @@ pub struct P2PSimConfig {
 }
 
 impl Default for P2PSimConfig {
+    /// 提供模拟的参考默认值。
     fn default() -> Self {
         Self {
             num_nodes: 15,

--- a/src/crypto/folding.rs
+++ b/src/crypto/folding.rs
@@ -272,6 +272,12 @@ impl<F: PrimeField> RelaxedR1CSBuilder<F> {
     }
 }
 
+impl<F: PrimeField> Default for RelaxedR1CSBuilder<F> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 /// 计算赋值向量的摘要。
 fn assignments_digest(assignments: &[Fr]) -> Fr {
     let mut acc = Fr::zero();
@@ -557,6 +563,12 @@ impl<F: PrimeField> IncrementalRelaxedCircuit<F> {
             .iter()
             .map(|circuit| circuit.num_constraints)
             .sum()
+    }
+}
+
+impl<F: PrimeField> Default for IncrementalRelaxedCircuit<F> {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/crypto/mod.rs
+++ b/src/crypto/mod.rs
@@ -6,13 +6,16 @@ use ark_ec::CurveGroup;
 use ark_ff::{BigInteger, One, PrimeField, Zero};
 use num_bigint::BigUint;
 
+/// BN254 曲线的阶，以十进制字符串表示。
 pub const CURVE_ORDER_STR: &str =
     "21888242871839275222246405745257275088548364400416034343698204186575808495617";
 
+/// 解析曲线阶为 `BigUint`，便于与随机标量进行模运算。
 pub fn curve_order() -> BigUint {
     BigUint::parse_bytes(CURVE_ORDER_STR.as_bytes(), 10).expect("invalid curve order")
 }
 
+/// 将有限域元素序列化为大端字节序。
 fn fq_to_bytes(f: &Fq) -> [u8; 32] {
     let bigint = f.into_bigint();
     let mut bytes = bigint.to_bytes_be();
@@ -26,6 +29,7 @@ fn fq_to_bytes(f: &Fq) -> [u8; 32] {
     out
 }
 
+/// BN254 Fq2 元素的序列化助手。
 fn fq2_to_bytes(f: &Fq2) -> [u8; 64] {
     let mut out = [0u8; 64];
     let c0 = fq_to_bytes(&f.c0);
@@ -35,6 +39,7 @@ fn fq2_to_bytes(f: &Fq2) -> [u8; 64] {
     out
 }
 
+/// 将 G1 群元素编码为 96 字节的非压缩表示。
 pub fn serialize_g1(point: &G1Projective) -> Vec<u8> {
     if point.is_zero() {
         return vec![0u8; 96];
@@ -47,6 +52,7 @@ pub fn serialize_g1(point: &G1Projective) -> Vec<u8> {
     out
 }
 
+/// 从 96 字节的非压缩表示恢复 G1 群元素。
 pub fn deserialize_g1(bytes: &[u8]) -> G1Projective {
     if bytes.len() != 96 {
         panic!("G1 serialization must be 96 bytes");
@@ -60,6 +66,7 @@ pub fn deserialize_g1(bytes: &[u8]) -> G1Projective {
     affine.into()
 }
 
+/// 将 G2 群元素编码为 192 字节的非压缩表示。
 pub fn serialize_g2(point: &G2Projective) -> Vec<u8> {
     if point.is_zero() {
         return vec![0u8; 192];
@@ -72,6 +79,7 @@ pub fn serialize_g2(point: &G2Projective) -> Vec<u8> {
     out
 }
 
+/// 从 192 字节的非压缩表示恢复 G2 群元素。
 pub fn deserialize_g2(bytes: &[u8]) -> G2Projective {
     if bytes.len() != 192 {
         panic!("G2 serialization must be 192 bytes");

--- a/src/roles/miner.rs
+++ b/src/roles/miner.rs
@@ -109,7 +109,7 @@ impl Miner {
             };
 
             for ((root_idx, nonce), hash) in metadata.into_iter().zip(hashes.into_iter()) {
-                if best_hash.as_ref().map_or(true, |current| hash < *current) {
+                if best_hash.as_ref().is_none_or(|current| hash < *current) {
                     best_root_idx = Some(root_idx);
                     best_nonce = Some(nonce);
                     best_hash = Some(hash);

--- a/src/roles/prover.rs
+++ b/src/roles/prover.rs
@@ -9,6 +9,12 @@ use crate::common::datastructures::{DPDPProof, DPDPTags};
 use crate::crypto::dpdp::DPDP;
 use crate::utils::log_msg;
 
+/// dPDP 挑战向量类型别名，元素为 (块索引, 挑战系数)。
+pub type ChallengeVector = Vec<(usize, BigUint)>;
+
+/// 每个挑战对应的贡献值，包含块索引、加权系数和缩放后的标签。
+pub type ContributionVector = Vec<(usize, BigUint, Vec<u8>)>;
+
 /// Prover 结构体定义了证明者的角色
 /// 证明者的核心职责是响应 dPDP（动态可证明数据拥有权）挑战，
 /// 生成一个密码学证明，以证实自己确实存储了特定的文件数据。
@@ -46,11 +52,7 @@ impl Prover {
         prev_hash: &str,
         timestamp: u64,
         challenge_size: Option<usize>,
-    ) -> (
-        DPDPProof,
-        Vec<(usize, BigUint)>,
-        Vec<(usize, BigUint, Vec<u8>)>,
-    ) {
+    ) -> (DPDPProof, ChallengeVector, ContributionVector) {
         // 1. 根据上下文（前一个块哈希、时间戳）和文件标签生成一个确定性的随机挑战
         let challenge = DPDP::gen_chal(prev_hash, timestamp, file_tags, challenge_size);
 

--- a/src/storage/manager.rs
+++ b/src/storage/manager.rs
@@ -16,12 +16,16 @@ use crate::storage::state::ServerStorage;
 use crate::utils::{h_join, sha256_hex};
 use serde_json::Value as JsonValue;
 
+type ChunkReplica = (Vec<u8>, Vec<u8>);
+type FileChunkMap = HashMap<usize, ChunkReplica>;
+type FileReplicaStore = HashMap<String, FileChunkMap>;
+
 struct StorageManagerInner {
     chunk_size: usize,
     max_storage: usize,
     used_space: usize,
     storage: ServerStorage,
-    files: HashMap<String, HashMap<usize, (Vec<u8>, Vec<u8>)>>,
+    files: FileReplicaStore,
     file_expected_chunks: HashMap<String, usize>,
     file_completed: HashSet<String>,
     file_pk_beta: HashMap<String, Vec<u8>>,
@@ -344,7 +348,7 @@ impl StorageManager {
         }
         let mut chunks = HashMap::new();
         let mut tags = Vec::new();
-        let mut sorted: Vec<(usize, (Vec<u8>, Vec<u8>))> = file_data.into_iter().collect();
+        let mut sorted: Vec<(usize, ChunkReplica)> = file_data.into_iter().collect();
         sorted.sort_by_key(|(idx, _)| *idx);
         for (idx, (data, tag)) in sorted {
             chunks.insert(idx, data);

--- a/src/storage/state.rs
+++ b/src/storage/state.rs
@@ -5,20 +5,11 @@ use serde::{Deserialize, Serialize};
 use crate::merkle::MerkleTree;
 use crate::utils::h_join;
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct TimeStateTree {
     pub leaves: HashMap<usize, String>,
     #[serde(skip)]
     pub merkle: Option<MerkleTree>,
-}
-
-impl Default for TimeStateTree {
-    fn default() -> Self {
-        Self {
-            leaves: HashMap::new(),
-            merkle: None,
-        }
-    }
 }
 
 impl TimeStateTree {
@@ -47,20 +38,11 @@ impl TimeStateTree {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct StorageStateTree {
     pub file_roots: HashMap<String, String>,
     #[serde(skip)]
     pub merkle: Option<MerkleTree>,
-}
-
-impl Default for StorageStateTree {
-    fn default() -> Self {
-        Self {
-            file_roots: HashMap::new(),
-            merkle: None,
-        }
-    }
 }
 
 impl StorageStateTree {


### PR DESCRIPTION
## Summary
- remove unused GPU feature toggles and clarify the CPU fallback poseidon helper
- document shared data structures, crypto helpers and configuration types
- reduce clippy warnings by refactoring node/user helpers, adding aliases and deriving defaults

## Testing
- cargo check
- cargo clippy --all-targets

------
https://chatgpt.com/codex/tasks/task_e_68d34b02624483279cbb3b4dd7f8a46b