### PR TITLE
Add Docker deployment tooling and configurable node settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e231f6134f61b71076a3eab506c379d4f36122f2af15a9ff04415ea4c3339e2"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -96,7 +96,7 @@ checksum = "3e0633414522a32ffaac8ac6cc8f748e090c5717661fddeea04219e2344f5f2a"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -292,6 +292,7 @@ dependencies = [
  "bincode",
  "chrono",
  "crossbeam-channel",
+ "ctrlc",
  "env_logger",
  "ff",
  "hex",
@@ -339,6 +340,12 @@ name = "cfg-if"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fd1289c04a9ea8cb22300a459a72a385d7c73d3259e2ed7dcb2af674838cfa9"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -419,6 +426,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "881c5d0a13b2f1498e2306e82cbada78390e152d4b1378fb28a84f4dcd0dc4f3"
+dependencies = [
+ "dispatch",
+ "nix",
+ "windows-sys 0.61.0",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,6 +446,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "dispatch"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd0c93bb4b0c6d9b77f4435b0ae98c24d17f1c45b2ff844c6151a07256ca923b"
 
 [[package]]
 name = "educe"
@@ -800,6 +824,18 @@ name = "memchr"
 version = "2.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "nix"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
 
 [[package]]
 name = "nova-snark"
@@ -1420,6 +1456,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
+dependencies = [
+ "windows-link 0.2.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ rayon = "1.10"
 nova-snark = "0.41"
 bincode = "1.3"
 ff = "0.13"
+ctrlc = "3.4"
 
 [features]
 default = []

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM rust:1.77 as builder
+WORKDIR /build
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
+RUN cargo build --release
+
+FROM debian:bookworm-slim
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /build/target/release/bpst /usr/local/bin/bpst
+COPY deployment/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+ENV RUST_LOG=info
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
+CMD []

--- a/deployment/README.md
+++ b/deployment/README.md
@@ -1,0 +1,121 @@
+# Docker 部署指南
+
+本目录提供了在 Linux 服务器上使用 Docker 一次性部署多个 BPoSt 节点的模板。部署时可显式指定每个节点监听的 IP、端口、存储容量、文件大小范围以及挖矿难度，避免再依赖额外的节点发现逻辑。
+
+## 目录结构
+
+- `config.example.json`：示例部署配置文件，定义存储节点、用户节点、观察者节点以及全局参数。
+- `docker-compose.yml`：使用单个容器运行集群的示例，容器内部由二进制的 `deploy` 子命令启动全部子进程。
+- `entrypoint.sh`：容器入口脚本，支持直接运行 `deploy` 配置，也支持基于环境变量启动单个节点。
+
+## 构建镜像
+
+在项目根目录执行：
+
+```bash
+docker build -t bpst:latest .
+```
+
+镜像会在构建阶段编译 release 版本的二进制，并在运行时使用精简的 Debian 容器。
+
+## 使用部署配置一次性启动全部进程
+
+1. 根据部署需要复制示例配置：
+   ```bash
+   cp deployment/config.example.json deployment/config.json
+   ```
+2. 编辑 `deployment/config.json`，为每个节点填写实际的 `host` 与 `port`（应使用服务器的对外 IP），以及可选的 `storage_kb`、`chunk_size`、`bobtail_k`、`mining_difficulty_hex` 等参数。
+   - `min_file_kb` / `max_file_kb` 决定文件生成的大小范围。
+   - `mining_difficulty_hex` 以 16 进制字符串指定全局挖矿难度，单个节点也可以通过 `nodes[*].mining_difficulty_hex` 覆盖。
+3. 根据节点暴露的端口调整 `deployment/docker-compose.yml` 中的 `ports` 映射。
+4. 启动：
+   ```bash
+   cd deployment
+   docker compose up -d
+   ```
+
+容器会在启动后执行 `bpst deploy /etc/bpst/deployment.json`，并在日志中打印每个子进程的 IP、端口、文件大小、挖矿难度等信息。配置中的第一个存储节点默认作为引导节点，其余节点自动连接到该地址；若需要自定义，可在节点条目中设置 `"bootstrap"` 字段（支持 `none`）。
+
+## 通过环境变量启动单个节点
+
+若希望在同一服务器上以多个容器分别运行单个节点，可使用入口脚本的 `BPST_ROLE` 模式：
+
+```bash
+docker run --rm \
+  -e BPST_ROLE=node \
+  -e BPST_NODE_ID=S0 \
+  -e BPST_HOST=0.0.0.0 \
+  -e BPST_PORT=62000 \
+  -e BPST_BOOTSTRAP=none \
+  -e BPST_CHUNK_SIZE=1024 \
+  -e BPST_STORAGE_KB=4096 \
+  -e BPST_BOBTAIL_K=3 \
+  -e BPST_MINING_DIFFICULTY_HEX=ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff \
+  -p 62000:62000 \
+  bpst:latest
+```
+
+支持的角色与必须变量：
+
+| 角色 (`BPST_ROLE`) | 必填变量 | 说明 |
+| --- | --- | --- |
+| `node` | `BPST_NODE_ID`, `BPST_HOST`, `BPST_PORT` | 其他可选：`BPST_BOOTSTRAP`、`BPST_CHUNK_SIZE`、`BPST_STORAGE_KB`、`BPST_BOBTAIL_K`、`BPST_MINING_DIFFICULTY_HEX` |
+| `user` | `BPST_USER_ID`, `BPST_HOST`, `BPST_PORT` | 可选：`BPST_BOOTSTRAP`（默认为 `127.0.0.1:62000`） |
+| `observer` | `BPST_OBSERVER_ID`, `BPST_HOST`, `BPST_PORT` | 可选：`BPST_BOOTSTRAP`（默认为 `127.0.0.1:62000`） |
+
+若容器既没有命令参数也未设置 `BPST_ROLE`，则默认运行 `bpst` 主程序原有的模拟流程。
+
+## 日志与状态
+
+- 部署过程中会输出每个子进程监听的 IP/端口、文件大小范围、挖矿难度阈值，便于在多服务器场景下登记与共享。
+- 按下 `Ctrl+C` 或向容器发送 `SIGTERM` 时，`deploy` 命令会优雅地终止所有子进程。
+
+## 自定义配置格式
+
+部署配置文件使用 JSON 格式，对应 `src/config.rs` 中的 `DeploymentConfig` 结构：
+
+```json
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 4096,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S0",
+      "host": "203.0.113.10",
+      "port": 62000,
+      "bootstrap": "none"
+    },
+    {
+      "node_id": "S1",
+      "host": "203.0.113.10",
+      "port": 62001,
+      "storage_kb": 6144,
+      "mining_difficulty_hex": "7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff"
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U0",
+      "host": "203.0.113.11",
+      "port": 62010,
+      "bootstrap": "203.0.113.10:62000"
+    }
+  ],
+  "observer": {
+    "observer_id": "OBS0",
+    "host": "203.0.113.12",
+    "port": 62020,
+    "bootstrap": "203.0.113.10:62000"
+  }
+}
+```
+
+- `nodes` 中首个条目默认作为引导节点；其 `bootstrap` 可留空或设置为 `"none"`。
+- 其余节点若未指定 `bootstrap`，会自动指向首个节点的地址。
+- `users`、`observer` 的 `bootstrap` 必须是有效的 `ip:port`，若省略则使用第一个节点的地址。
+
+通过上述配置即可在一个服务器上部署多个节点，并将监听地址（IP/端口）、文件大小范围与挖矿难度显式暴露给其他服务器或调度系统。

--- a/deployment/config.example.json
+++ b/deployment/config.example.json
@@ -1,0 +1,33 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 4096,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S0",
+      "host": "0.0.0.0",
+      "port": 62000
+    },
+    {
+      "node_id": "S1",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 6144
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U0",
+      "host": "0.0.0.0",
+      "port": 62010
+    }
+  ],
+  "observer": {
+    "observer_id": "OBS0",
+    "host": "0.0.0.0",
+    "port": 62020
+  }
+}

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,0 +1,17 @@
+version: "3.9"
+
+services:
+  bpst-cluster:
+    build: ..
+    image: bpst:latest
+    container_name: bpst-cluster
+    environment:
+      - BPST_CONFIG=/etc/bpst/deployment.json
+    volumes:
+      - ./config.example.json:/etc/bpst/deployment.json:ro
+    ports:
+      - "62000:62000"
+      - "62001:62001"
+      - "62010:62010"
+      - "62020:62020"
+    restart: unless-stopped

--- a/deployment/entrypoint.sh
+++ b/deployment/entrypoint.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env sh
+set -eu
+
+if [ "$#" -gt 0 ]; then
+  case "$1" in
+    bpst)
+      shift
+      exec bpst "$@"
+      ;;
+    deploy|node|user|observer)
+      exec bpst "$@"
+      ;;
+  esac
+fi
+
+if [ "${BPST_CONFIG:-}" != "" ]; then
+  exec bpst deploy "$BPST_CONFIG"
+fi
+
+if [ "${BPST_ROLE:-}" != "" ]; then
+  case "$BPST_ROLE" in
+    node)
+      : "${BPST_NODE_ID:?需要设置 BPST_NODE_ID}"
+      : "${BPST_HOST:?需要设置 BPST_HOST}"
+      : "${BPST_PORT:?需要设置 BPST_PORT}"
+      CHUNK_SIZE="${BPST_CHUNK_SIZE:-1024}"
+      STORAGE_KB="${BPST_STORAGE_KB:-2048}"
+      BOBTAIL_K="${BPST_BOBTAIL_K:-3}"
+      BOOTSTRAP="${BPST_BOOTSTRAP:-none}"
+      STORAGE_BYTES=$((STORAGE_KB * 1024))
+      exec bpst node "$BPST_NODE_ID" "$BPST_HOST" "$BPST_PORT" "$BOOTSTRAP" "$CHUNK_SIZE" "$STORAGE_BYTES" "$BOBTAIL_K"
+      ;;
+    user)
+      : "${BPST_USER_ID:?需要设置 BPST_USER_ID}"
+      : "${BPST_HOST:?需要设置 BPST_HOST}"
+      : "${BPST_PORT:?需要设置 BPST_PORT}"
+      BOOTSTRAP="${BPST_BOOTSTRAP:-127.0.0.1:62000}"
+      exec bpst user "$BPST_USER_ID" "$BPST_HOST" "$BPST_PORT" "$BOOTSTRAP"
+      ;;
+    observer)
+      : "${BPST_OBSERVER_ID:?需要设置 BPST_OBSERVER_ID}"
+      : "${BPST_HOST:?需要设置 BPST_HOST}"
+      : "${BPST_PORT:?需要设置 BPST_PORT}"
+      BOOTSTRAP="${BPST_BOOTSTRAP:-127.0.0.1:62000}"
+      exec bpst observer "$BPST_OBSERVER_ID" "$BPST_HOST" "$BPST_PORT" "$BOOTSTRAP"
+      ;;
+    *)
+      echo "未知的 BPST_ROLE: $BPST_ROLE" >&2
+      exit 1
+      ;;
+  esac
+fi
+
+exec bpst "$@"

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,8 @@
+use std::fs;
+use std::path::Path;
+
 use serde::{Deserialize, Serialize};
+use thiserror::Error;
 
 /// 控制 P2P 模拟行为的一组参数。
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -18,6 +22,156 @@ pub struct P2PSimConfig {
     pub bid_wait_sec: u64,
     pub min_storage_rounds: usize,
     pub max_storage_rounds: usize,
+}
+
+#[derive(Debug, Error)]
+pub enum DeploymentConfigError {
+    #[error("无法读取部署配置文件 {path}: {source}")]
+    Io {
+        #[source]
+        source: std::io::Error,
+        path: String,
+    },
+    #[error("无法解析部署配置文件 {path}: {source}")]
+    Parse {
+        #[source]
+        source: serde_json::Error,
+        path: String,
+    },
+    #[error("部署配置无效: {message}")]
+    Invalid { message: String },
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct DeploymentConfig {
+    #[serde(default)]
+    pub nodes: Vec<NodeDeployment>,
+    #[serde(default)]
+    pub users: Vec<UserDeployment>,
+    #[serde(default)]
+    pub observer: Option<ObserverDeployment>,
+    #[serde(default)]
+    pub chunk_size: Option<usize>,
+    #[serde(default)]
+    pub min_file_kb: Option<usize>,
+    #[serde(default)]
+    pub max_file_kb: Option<usize>,
+    #[serde(default)]
+    pub bobtail_k: Option<usize>,
+    #[serde(default)]
+    pub default_storage_kb: Option<usize>,
+    #[serde(default)]
+    pub mining_difficulty_hex: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct NodeDeployment {
+    pub node_id: String,
+    pub host: String,
+    pub port: u16,
+    #[serde(default)]
+    pub storage_kb: Option<usize>,
+    #[serde(default)]
+    pub chunk_size: Option<usize>,
+    #[serde(default)]
+    pub bobtail_k: Option<usize>,
+    #[serde(default)]
+    pub bootstrap: Option<String>,
+    #[serde(default)]
+    pub mining_difficulty_hex: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UserDeployment {
+    pub user_id: String,
+    pub host: String,
+    pub port: u16,
+    #[serde(default)]
+    pub bootstrap: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ObserverDeployment {
+    pub observer_id: String,
+    pub host: String,
+    pub port: u16,
+    #[serde(default)]
+    pub bootstrap: Option<String>,
+}
+
+impl DeploymentConfig {
+    pub fn from_path<P: AsRef<Path>>(path: P) -> Result<Self, DeploymentConfigError> {
+        let path_ref = path.as_ref();
+        let data = fs::read_to_string(path_ref).map_err(|source| DeploymentConfigError::Io {
+            source,
+            path: path_ref.display().to_string(),
+        })?;
+        let cfg: DeploymentConfig =
+            serde_json::from_str(&data).map_err(|source| DeploymentConfigError::Parse {
+                source,
+                path: path_ref.display().to_string(),
+            })?;
+        Ok(cfg)
+    }
+
+    pub fn ensure_nodes(&self) -> Result<(), DeploymentConfigError> {
+        if self.nodes.is_empty() {
+            return Err(DeploymentConfigError::Invalid {
+                message: String::from("nodes 列表不能为空"),
+            });
+        }
+        Ok(())
+    }
+
+    pub fn default_chunk_size(&self) -> usize {
+        self.chunk_size
+            .unwrap_or_else(|| P2PSimConfig::default().chunk_size)
+    }
+
+    pub fn default_bobtail_k(&self) -> usize {
+        self.bobtail_k
+            .unwrap_or_else(|| P2PSimConfig::default().bobtail_k)
+    }
+
+    pub fn default_storage_kb(&self) -> usize {
+        self.default_storage_kb
+            .or(self.nodes.iter().filter_map(|n| n.storage_kb).min())
+            .unwrap_or_else(|| P2PSimConfig::default().min_storage_kb)
+    }
+
+    pub fn default_min_file_kb(&self) -> usize {
+        self.min_file_kb
+            .unwrap_or_else(|| P2PSimConfig::default().min_file_kb)
+    }
+
+    pub fn default_max_file_kb(&self) -> usize {
+        self.max_file_kb
+            .unwrap_or_else(|| P2PSimConfig::default().max_file_kb)
+    }
+
+    pub fn to_sim_config(&self) -> P2PSimConfig {
+        let mut cfg = P2PSimConfig::default();
+        cfg.num_nodes = self.nodes.len().max(1);
+        cfg.num_file_owners = self.users.len();
+        cfg.min_storage_nodes = cfg.num_nodes;
+        cfg.max_storage_nodes = cfg.num_nodes;
+        cfg.chunk_size = self.default_chunk_size();
+        cfg.bobtail_k = self.default_bobtail_k();
+        cfg.min_file_kb = self.default_min_file_kb();
+        cfg.max_file_kb = self.default_max_file_kb();
+        cfg.min_storage_kb = self.default_storage_kb();
+        cfg.max_storage_kb = self.default_storage_kb().max(
+            self.nodes
+                .iter()
+                .filter_map(|n| n.storage_kb)
+                .max()
+                .unwrap_or(cfg.min_storage_kb),
+        );
+        if let Some(first) = self.nodes.first() {
+            cfg.base_port = first.port;
+        }
+        cfg
+    }
 }
 
 impl Default for P2PSimConfig {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
-// 引入 bpst 项目中的 P2PSimConfig 配置模块
-use bpst::config::P2PSimConfig;
+// 引入 bpst 项目中的配置模块
+use bpst::config::{DeploymentConfig, P2PSimConfig};
 // 引入 bpst 项目中的 simulation 模块，包含运行节点、用户进程和P2P模拟的功能
 use bpst::simulation::{
-    run_node_process_from_args, run_observer_process_from_args, run_p2p_simulation,
+    run_deployment, run_node_process_from_args, run_observer_process_from_args, run_p2p_simulation,
     run_user_process_from_args,
 };
 
@@ -32,6 +32,21 @@ fn main() {
             }
             "observer" => {
                 run_observer_process_from_args(args);
+                return;
+            }
+            "deploy" => {
+                let config_path = args
+                    .next()
+                    .expect("缺少部署配置文件路径参数，例如: bpst deploy ./deployment/config.json");
+                let deployment_config =
+                    DeploymentConfig::from_path(&config_path).unwrap_or_else(|err| {
+                        eprintln!("无法加载部署配置文件 {config_path}: {err}");
+                        std::process::exit(1);
+                    });
+                if let Err(err) = run_deployment(deployment_config) {
+                    eprintln!("部署失败: {err}");
+                    std::process::exit(1);
+                }
                 return;
             }
             // 忽略其他子命令

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -7,12 +7,15 @@ use std::time::{Duration, Instant};
 use crossbeam_channel::unbounded;
 use rand::Rng;
 
-use crate::config::P2PSimConfig;
-use crate::p2p::node::Node;
+use crate::config::{DeploymentConfig, DeploymentConfigError, NodeDeployment, P2PSimConfig};
+use crate::p2p::node::{Node, DEFAULT_DIFFICULTY_HEX};
 use crate::p2p::observer_node::ObserverNode;
 use crate::p2p::user_node::UserNode;
 use crate::roles::file_owner::FileOwner;
 use crate::utils::log_msg;
+use num_bigint::BigUint;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 pub fn run_p2p_simulation(config: P2PSimConfig) {
     log_msg(
@@ -206,9 +209,316 @@ pub fn run_p2p_simulation(config: P2PSimConfig) {
     );
 }
 
+pub fn run_deployment(config: DeploymentConfig) -> Result<(), DeploymentConfigError> {
+    config.ensure_nodes()?;
+    let sim_config = config.to_sim_config();
+    let config_json = serde_json::to_string(&sim_config).expect("无法序列化部署配置");
+    let current_exe = env::current_exe().expect("无法定位当前可执行文件");
+    let default_bootstrap =
+        normalize_node_addr(config.nodes.first().expect("至少应存在一个节点以供部署"))?;
+    let default_storage_kb = config.default_storage_kb();
+    let global_difficulty = if let Some(raw) = config.mining_difficulty_hex.as_ref() {
+        Some(normalize_difficulty_hex(raw)?)
+    } else {
+        None
+    };
+
+    log_msg(
+        "INFO",
+        "DEPLOY",
+        Some(String::from("CONFIG")),
+        &format!(
+            "一次性部署 {} 个存储节点、{} 个用户节点。文件大小范围: {}-{} KB, 块大小: {} 字节, Bobtail k 值: {}。",
+            sim_config.num_nodes,
+            sim_config.num_file_owners,
+            sim_config.min_file_kb,
+            sim_config.max_file_kb,
+            sim_config.chunk_size,
+            sim_config.bobtail_k
+        ),
+    );
+    let difficulty_for_log = global_difficulty
+        .clone()
+        .unwrap_or_else(|| DEFAULT_DIFFICULTY_HEX.to_string());
+    log_msg(
+        "INFO",
+        "DEPLOY",
+        Some(String::from("CONFIG")),
+        &format!("默认挖矿难度阈值: 0x{}", difficulty_for_log),
+    );
+
+    let mut children: Vec<(String, Child)> = Vec::new();
+    for (idx, node_cfg) in config.nodes.iter().enumerate() {
+        let chunk_size = node_cfg.chunk_size.unwrap_or(sim_config.chunk_size);
+        let storage_kb = node_cfg.storage_kb.unwrap_or(default_storage_kb);
+        let storage_bytes = storage_kb * 1024;
+        let bobtail_k = node_cfg.bobtail_k.unwrap_or(sim_config.bobtail_k);
+        let bootstrap = if let Some(override_bootstrap) = node_cfg.bootstrap.as_ref() {
+            normalize_bootstrap_addr(override_bootstrap, true)?
+        } else if idx == 0 {
+            String::from("none")
+        } else {
+            default_bootstrap.clone()
+        };
+        let node_difficulty = if let Some(raw) = node_cfg.mining_difficulty_hex.as_ref() {
+            Some(normalize_difficulty_hex(raw)?)
+        } else {
+            global_difficulty.clone()
+        };
+        log_msg(
+            "INFO",
+            "DEPLOY",
+            Some(node_cfg.node_id.clone()),
+            &format!(
+                "节点将监听 {}:{}，存储容量 {} KB，数据块 {} 字节，Bobtail k = {}，挖矿难度 0x{}。",
+                node_cfg.host,
+                node_cfg.port,
+                storage_kb,
+                chunk_size,
+                bobtail_k,
+                node_difficulty
+                    .clone()
+                    .unwrap_or_else(|| DEFAULT_DIFFICULTY_HEX.to_string())
+            ),
+        );
+
+        let mut cmd = Command::new(&current_exe);
+        cmd.arg("node")
+            .arg(node_cfg.node_id.clone())
+            .arg(node_cfg.host.clone())
+            .arg(node_cfg.port.to_string())
+            .arg(bootstrap.clone())
+            .arg(chunk_size.to_string())
+            .arg(storage_bytes.to_string())
+            .arg(bobtail_k.to_string())
+            .env("P2P_SIM_CONFIG", config_json.clone());
+        if let Some(diff_hex) = node_difficulty {
+            cmd.env("BPST_MINING_DIFFICULTY_HEX", diff_hex);
+        }
+
+        match cmd.spawn() {
+            Ok(child) => {
+                log_msg(
+                    "INFO",
+                    "DEPLOY",
+                    Some(node_cfg.node_id.clone()),
+                    &format!("已启动节点进程，PID = {}", child.id()),
+                );
+                children.push((format!("node-{}", node_cfg.node_id), child));
+            }
+            Err(e) => {
+                log_msg(
+                    "ERROR",
+                    "DEPLOY",
+                    Some(node_cfg.node_id.clone()),
+                    &format!("启动节点失败: {e}"),
+                );
+            }
+        }
+    }
+
+    for user_cfg in &config.users {
+        let bootstrap = if let Some(override_bootstrap) = user_cfg.bootstrap.as_ref() {
+            normalize_bootstrap_addr(override_bootstrap, false)?
+        } else {
+            default_bootstrap.clone()
+        };
+        log_msg(
+            "INFO",
+            "DEPLOY",
+            Some(user_cfg.user_id.clone()),
+            &format!(
+                "用户节点监听 {}:{}，连接引导节点 {}",
+                user_cfg.host, user_cfg.port, bootstrap
+            ),
+        );
+        let mut cmd = Command::new(&current_exe);
+        cmd.arg("user")
+            .arg(user_cfg.user_id.clone())
+            .arg(user_cfg.host.clone())
+            .arg(user_cfg.port.to_string())
+            .arg(bootstrap)
+            .env("P2P_SIM_CONFIG", config_json.clone());
+        match cmd.spawn() {
+            Ok(child) => {
+                log_msg(
+                    "INFO",
+                    "DEPLOY",
+                    Some(user_cfg.user_id.clone()),
+                    &format!("已启动用户进程，PID = {}", child.id()),
+                );
+                children.push((format!("user-{}", user_cfg.user_id), child));
+            }
+            Err(e) => {
+                log_msg(
+                    "ERROR",
+                    "DEPLOY",
+                    Some(user_cfg.user_id.clone()),
+                    &format!("启动用户节点失败: {e}"),
+                );
+            }
+        }
+    }
+
+    if let Some(observer_cfg) = config.observer.as_ref() {
+        let bootstrap = if let Some(override_bootstrap) = observer_cfg.bootstrap.as_ref() {
+            normalize_bootstrap_addr(override_bootstrap, false)?
+        } else {
+            default_bootstrap.clone()
+        };
+        log_msg(
+            "INFO",
+            "DEPLOY",
+            Some(observer_cfg.observer_id.clone()),
+            &format!(
+                "观察者节点监听 {}:{}，连接引导节点 {}",
+                observer_cfg.host, observer_cfg.port, bootstrap
+            ),
+        );
+        let mut cmd = Command::new(&current_exe);
+        cmd.arg("observer")
+            .arg(observer_cfg.observer_id.clone())
+            .arg(observer_cfg.host.clone())
+            .arg(observer_cfg.port.to_string())
+            .arg(bootstrap)
+            .env("P2P_SIM_CONFIG", config_json);
+        match cmd.spawn() {
+            Ok(child) => {
+                log_msg(
+                    "INFO",
+                    "DEPLOY",
+                    Some(observer_cfg.observer_id.clone()),
+                    &format!("已启动观察者进程，PID = {}", child.id()),
+                );
+                children.push((String::from("observer"), child));
+            }
+            Err(e) => {
+                log_msg(
+                    "ERROR",
+                    "DEPLOY",
+                    Some(observer_cfg.observer_id.clone()),
+                    &format!("启动观察者节点失败: {e}"),
+                );
+            }
+        }
+    }
+
+    let running = Arc::new(AtomicBool::new(true));
+    let signal_flag = Arc::clone(&running);
+    ctrlc::set_handler(move || {
+        signal_flag.store(false, Ordering::SeqCst);
+    })
+    .map_err(|e| DeploymentConfigError::Invalid {
+        message: format!("无法注册终止信号处理器: {e}"),
+    })?;
+
+    while running.load(Ordering::SeqCst) {
+        thread::sleep(Duration::from_secs(5));
+        let mut idx = 0;
+        while idx < children.len() {
+            let (name, child) = &mut children[idx];
+            match child.try_wait() {
+                Ok(Some(status)) => {
+                    log_msg(
+                        "WARN",
+                        "DEPLOY",
+                        Some(name.clone()),
+                        &format!("进程已退出，状态: {status}"),
+                    );
+                    children.remove(idx);
+                }
+                Ok(None) => {
+                    idx += 1;
+                }
+                Err(e) => {
+                    log_msg(
+                        "ERROR",
+                        "DEPLOY",
+                        Some(name.clone()),
+                        &format!("检查子进程状态失败: {e}"),
+                    );
+                    idx += 1;
+                }
+            }
+        }
+        if children.is_empty() {
+            log_msg(
+                "WARN",
+                "DEPLOY",
+                Some(String::from("MAIN")),
+                "所有子进程均已退出，部署进程将结束。",
+            );
+            return Ok(());
+        }
+    }
+
+    log_msg(
+        "INFO",
+        "DEPLOY",
+        Some(String::from("MAIN")),
+        "收到终止信号，正在停止所有节点进程...",
+    );
+    for (name, mut child) in children {
+        if let Err(e) = child.kill() {
+            log_msg(
+                "ERROR",
+                "DEPLOY",
+                Some(name.clone()),
+                &format!("终止进程失败: {e}"),
+            );
+        }
+        let _ = child.wait();
+    }
+    Ok(())
+}
+
+fn normalize_node_addr(node: &NodeDeployment) -> Result<String, DeploymentConfigError> {
+    let addr = format!("{}:{}", node.host, node.port);
+    addr.parse::<SocketAddr>()
+        .map(|socket| socket.to_string())
+        .map_err(|_| DeploymentConfigError::Invalid {
+            message: format!("节点 {} 的监听地址无效: {}", node.node_id, addr),
+        })
+}
+
+fn normalize_bootstrap_addr(addr: &str, allow_none: bool) -> Result<String, DeploymentConfigError> {
+    if allow_none && addr.eq_ignore_ascii_case("none") {
+        return Ok(String::from("none"));
+    }
+    addr.parse::<SocketAddr>()
+        .map(|socket| socket.to_string())
+        .map_err(|_| DeploymentConfigError::Invalid {
+            message: format!("无效的引导节点地址: {addr}"),
+        })
+}
+
 fn load_config_from_env() -> P2PSimConfig {
     let raw = env::var("P2P_SIM_CONFIG").expect("子进程缺少 P2P_SIM_CONFIG 环境变量");
     serde_json::from_str(&raw).expect("无法解析 P2P_SIM_CONFIG")
+}
+
+fn load_difficulty_override_from_env() -> Option<BigUint> {
+    match env::var("BPST_MINING_DIFFICULTY_HEX") {
+        Ok(raw) => parse_difficulty_hex(&raw),
+        Err(_) => None,
+    }
+}
+
+fn parse_difficulty_hex(raw: &str) -> Option<BigUint> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    let normalized = trimmed.strip_prefix("0x").unwrap_or(trimmed);
+    BigUint::parse_bytes(normalized.as_bytes(), 16)
+}
+
+fn normalize_difficulty_hex(raw: &str) -> Result<String, DeploymentConfigError> {
+    parse_difficulty_hex(raw)
+        .map(|v| format!("{:x}", v))
+        .ok_or_else(|| DeploymentConfigError::Invalid {
+            message: format!("无效的挖矿难度十六进制值: {raw}"),
+        })
 }
 
 pub fn run_node_process_from_args<I>(mut args: I)
@@ -243,6 +553,7 @@ where
         .expect("缺少 bobtail_k 参数")
         .parse()
         .expect("无法解析 bobtail_k");
+    let difficulty_override = load_difficulty_override_from_env();
     let (report_tx, _report_rx) = unbounded();
     let node = Box::new(Node::new(
         node_id,
@@ -252,6 +563,7 @@ where
         chunk_size,
         max_storage,
         bobtail_k,
+        difficulty_override,
         report_tx,
     ));
     node.run();


### PR DESCRIPTION
## Summary
- add deployment-specific configuration structures and a `deploy` subcommand that launches nodes from a JSON config
- allow node processes to override mining difficulty via environment variables while keeping existing defaults
- provide Dockerfile, entrypoint script, docker-compose example, and documentation for Linux container deployment

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d3a6939410832788d2aabb670c1b95