### PR TITLE
refactor: refresh docker deployment templates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,29 +1,39 @@
-# ---- 阶段 1: 构建 ----
-# 使用最新的 Rust 镜像，确保 cargo 工具链足够新
-FROM rust:latest AS builder
+# ---- Stage 1: Build -------------------------------------------------------
+# Use the latest stable Rust toolchain to compile the project.
+FROM rust:1-bookworm AS builder
 
-# 为静态编译安装 musl 工具链目标
-RUN rustup target add x86_64-unknown-linux-musl
+# Create a new empty shell project to cache dependencies.
+WORKDIR /usr/src/app
 
-# 创建工作目录
-WORKDIR /build
+# Install build dependencies required by crates that rely on OpenSSL or pkg-config.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends pkg-config libssl-dev clang \
+    && rm -rf /var/lib/apt/lists/*
 
-# 复制所有项目文件
-# 注意：确保你的 .dockerignore 文件配置正确，避免复制不必要的文件
-COPY . .
+# Copy manifests first to leverage Docker layer caching.
+COPY Cargo.toml Cargo.lock ./
+COPY src ./src
 
-# 使用 musl 目标进行静态编译
-# 注意：需要加上 --target 参数
-RUN cargo build --release --target x86_64-unknown-linux-musl
+# Build the project in release mode.
+RUN cargo build --release
 
-
-# ---- 阶段 2: 运行 ----
-# 使用你期望的、精简的最终镜像
+# ---- Stage 2: Runtime -----------------------------------------------------
 FROM debian:bookworm-slim
 
-# 从构建阶段复制编译好的、静态链接的二进制文件
-# 注意路径的变化，因为它是在 musl 目标下生成的
-COPY --from=builder /build/target/x86_64-unknown-linux-musl/release/bpst /usr/local/bin/bpst
+# Install runtime dependencies and helper tools for templating configs.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates gettext-base \
+    && rm -rf /var/lib/apt/lists/*
 
-# 设置容器的启动命令
+# Copy the compiled binary from the builder stage.
+COPY --from=builder /usr/src/app/target/release/bpst /usr/local/bin/bpst
+
+# Copy the deployment tooling.
+COPY deployment/entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
+# Create directory for configuration files.
+RUN mkdir -p /etc/bpst
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 CMD ["bpst"]

--- a/deployment/config.json
+++ b/deployment/config.json
@@ -8,12 +8,13 @@
   "nodes": [
     {
       "node_id": "S0",
-      "host": "0.0.0.0",
-      "port": 62000
+      "host": "127.0.0.1",
+      "port": 62000,
+      "bootstrap": "none"
     },
     {
       "node_id": "S1",
-      "host": "0.0.0.0",
+      "host": "127.0.0.1",
       "port": 62001,
       "storage_kb": 6144
     }
@@ -21,13 +22,15 @@
   "users": [
     {
       "user_id": "U0",
-      "host": "0.0.0.0",
-      "port": 62010
+      "host": "127.0.0.1",
+      "port": 62010,
+      "bootstrap": "127.0.0.1:62000"
     }
   ],
   "observer": {
     "observer_id": "OBS0",
-    "host": "0.0.0.0",
-    "port": 62020
+    "host": "127.0.0.1",
+    "port": 62020,
+    "bootstrap": "127.0.0.1:62000"
   }
 }

--- a/deployment/config.template.json
+++ b/deployment/config.template.json
@@ -8,13 +8,13 @@
   "nodes": [
     {
       "node_id": "S0",
-      "host": "127.0.0.1",
+      "host": "${BPST_ADVERTISE_IP}",
       "port": 62000,
       "bootstrap": "none"
     },
     {
       "node_id": "S1",
-      "host": "127.0.0.1",
+      "host": "${BPST_ADVERTISE_IP}",
       "port": 62001,
       "storage_kb": 6144
     }
@@ -22,15 +22,15 @@
   "users": [
     {
       "user_id": "U0",
-      "host": "127.0.0.1",
+      "host": "${BPST_ADVERTISE_IP}",
       "port": 62010,
-      "bootstrap": "127.0.0.1:62000"
+      "bootstrap": "${BPST_BOOTSTRAP_IP}:62000"
     }
   ],
   "observer": {
     "observer_id": "OBS0",
-    "host": "127.0.0.1",
+    "host": "${BPST_ADVERTISE_IP}",
     "port": 62020,
-    "bootstrap": "127.0.0.1:62000"
+    "bootstrap": "${BPST_BOOTSTRAP_IP}:62000"
   }
 }

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -1,14 +1,18 @@
-version: "3.9"
-
 services:
   bpst-cluster:
-    build: ..
+    build:
+      context: ..
+      dockerfile: Dockerfile
     image: bpst:latest
     container_name: bpst-cluster
     environment:
-      - BPST_CONFIG=/etc/bpst/deployment.json
+      BPST_CONFIG_TEMPLATE: /etc/bpst/config.template.json
+      BPST_CONFIG_OUTPUT: /etc/bpst/deployment.json
+      BPST_CONFIG: /etc/bpst/deployment.json
+      BPST_ADVERTISE_IP: ${BPST_ADVERTISE_IP:-127.0.0.1}
+      BPST_BOOTSTRAP_IP: ${BPST_BOOTSTRAP_IP:-127.0.0.1}
     volumes:
-      - ./config.example.json:/etc/bpst/deployment.json:ro
+      - ./config.template.json:/etc/bpst/config.template.json:ro
     ports:
       - "62000:62000"
       - "62001:62001"

--- a/deployment/entrypoint.sh
+++ b/deployment/entrypoint.sh
@@ -1,23 +1,58 @@
 #!/usr/bin/env sh
-set -eu
+set -euo pipefail
+
+DEFAULT_TEMPLATE="/etc/bpst/config.template.json"
+DEFAULT_OUTPUT="/etc/bpst/deployment.json"
+
+render_config() {
+  local template="${BPST_CONFIG_TEMPLATE:-}" output="${BPST_CONFIG_OUTPUT:-}" tmp
+
+  if [ -z "$template" ] && [ -f "$DEFAULT_TEMPLATE" ]; then
+    template="$DEFAULT_TEMPLATE"
+  fi
+
+  if [ -z "$template" ]; then
+    return 0
+  fi
+
+  if [ -z "$output" ]; then
+    if [ -n "${BPST_CONFIG:-}" ]; then
+      output="$BPST_CONFIG"
+    else
+      output="$DEFAULT_OUTPUT"
+    fi
+  fi
+
+  mkdir -p "$(dirname "$output")"
+
+  export BPST_ADVERTISE_IP="${BPST_ADVERTISE_IP:-127.0.0.1}"
+  export BPST_BOOTSTRAP_IP="${BPST_BOOTSTRAP_IP:-$BPST_ADVERTISE_IP}"
+
+  tmp="$(mktemp)"
+  envsubst <"$template" >"$tmp"
+  mv "$tmp" "$output"
+  chmod 644 "$output"
+
+  BPST_CONFIG="$output"
+  export BPST_CONFIG
+  echo "[entrypoint] rendered deployment config to $output"
+}
+
+render_config
 
 if [ "$#" -gt 0 ]; then
   case "$1" in
-    bpst)
-      shift
-      exec bpst "$@"
-      ;;
-    deploy|node|user|observer)
+    bpst|deploy|node|user|observer)
       exec bpst "$@"
       ;;
   esac
 fi
 
-if [ "${BPST_CONFIG:-}" != "" ]; then
+if [ -n "${BPST_CONFIG:-}" ] && [ -f "$BPST_CONFIG" ]; then
   exec bpst deploy "$BPST_CONFIG"
 fi
 
-if [ "${BPST_ROLE:-}" != "" ]; then
+if [ -n "${BPST_ROLE:-}" ]; then
   case "$BPST_ROLE" in
     node)
       : "${BPST_NODE_ID:?需要设置 BPST_NODE_ID}"
@@ -26,7 +61,8 @@ if [ "${BPST_ROLE:-}" != "" ]; then
       CHUNK_SIZE="${BPST_CHUNK_SIZE:-1024}"
       STORAGE_KB="${BPST_STORAGE_KB:-2048}"
       BOBTAIL_K="${BPST_BOBTAIL_K:-3}"
-      BOOTSTRAP="${BPST_BOOTSTRAP:-none}"
+      BOOTSTRAP_DEFAULT="${BPST_BOOTSTRAP_IP}:62000"
+      BOOTSTRAP="${BPST_BOOTSTRAP:-$BOOTSTRAP_DEFAULT}"
       STORAGE_BYTES=$((STORAGE_KB * 1024))
       exec bpst node "$BPST_NODE_ID" "$BPST_HOST" "$BPST_PORT" "$BOOTSTRAP" "$CHUNK_SIZE" "$STORAGE_BYTES" "$BOBTAIL_K"
       ;;
@@ -34,14 +70,16 @@ if [ "${BPST_ROLE:-}" != "" ]; then
       : "${BPST_USER_ID:?需要设置 BPST_USER_ID}"
       : "${BPST_HOST:?需要设置 BPST_HOST}"
       : "${BPST_PORT:?需要设置 BPST_PORT}"
-      BOOTSTRAP="${BPST_BOOTSTRAP:-127.0.0.1:62000}"
+      BOOTSTRAP_DEFAULT="${BPST_BOOTSTRAP_IP}:62000"
+      BOOTSTRAP="${BPST_BOOTSTRAP:-$BOOTSTRAP_DEFAULT}"
       exec bpst user "$BPST_USER_ID" "$BPST_HOST" "$BPST_PORT" "$BOOTSTRAP"
       ;;
     observer)
       : "${BPST_OBSERVER_ID:?需要设置 BPST_OBSERVER_ID}"
       : "${BPST_HOST:?需要设置 BPST_HOST}"
       : "${BPST_PORT:?需要设置 BPST_PORT}"
-      BOOTSTRAP="${BPST_BOOTSTRAP:-127.0.0.1:62000}"
+      BOOTSTRAP_DEFAULT="${BPST_BOOTSTRAP_IP}:62000"
+      BOOTSTRAP="${BPST_BOOTSTRAP:-$BOOTSTRAP_DEFAULT}"
       exec bpst observer "$BPST_OBSERVER_ID" "$BPST_HOST" "$BPST_PORT" "$BOOTSTRAP"
       ;;
     *)


### PR DESCRIPTION
## Summary
- refresh the Dockerfile to use the latest stable Rust and runtime dependencies while bundling the new entrypoint tooling
- add a templated deployment config with IP placeholders and render it automatically in the container entrypoint
- update docker-compose and documentation to default to 127.0.0.1 locally and explain how to override IPs for multi-cloud setups

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d4a3bad7608327af919b12a83c38e7