### PR TITLE
Log console output to file with timestamps

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,13 +1,18 @@
 // 引入 bpst 项目中的配置模块
 use bpst::config::{DeploymentConfig, P2PSimConfig};
+// 初始化日志系统
+use bpst::utils::init_logging;
 // 引入 bpst 项目中的 simulation 模块，包含运行节点、用户进程和P2P模拟的功能
 use bpst::simulation::{
     run_deployment, run_node_process_from_args, run_observer_process_from_args, run_p2p_simulation,
     run_user_process_from_args,
 };
+use log::error;
 
 // Rust 程序的主入口函数
 fn main() {
+    // 初始化日志系统，确保控制台输出同时写入日志文件
+    init_logging();
     // 获取命令行参数的迭代器
     let mut args = std::env::args();
     // 跳过可执行文件路径
@@ -38,13 +43,15 @@ fn main() {
                 let config_path = args
                     .next()
                     .expect("缺少部署配置文件路径参数，例如: bpst deploy ./deployment/config.json");
-                let deployment_config =
-                    DeploymentConfig::from_path(&config_path).unwrap_or_else(|err| {
-                        eprintln!("无法加载部署配置文件 {config_path}: {err}");
+                let deployment_config = match DeploymentConfig::from_path(&config_path) {
+                    Ok(config) => config,
+                    Err(err) => {
+                        error!("无法加载部署配置文件 {}: {}", config_path, err);
                         std::process::exit(1);
-                    });
+                    }
+                };
                 if let Err(err) = run_deployment(deployment_config) {
-                    eprintln!("部署失败: {err}");
+                    error!("部署失败: {}", err);
                     std::process::exit(1);
                 }
                 return;
@@ -56,7 +63,7 @@ fn main() {
     // 如果没有子命令，则运行P2P模拟
     // 定义 P2P 模拟的配置
     let config = P2PSimConfig {
-        num_nodes: 7,           // 节点数量
+        num_nodes: 7,            // 节点数量
         num_file_owners: 2,      // 文件所有者数量
         sim_duration_sec: 90000, // 模拟持续时间（秒）
         chunk_size: 64,          // 数据块大小
@@ -70,7 +77,7 @@ fn main() {
         max_storage_kb: 256,     // 最大存储空间 (KB)
         bid_wait_sec: 20,        // 投标等待时间（秒）
         min_storage_rounds: 5,   // 最小存储轮次
-        max_storage_rounds: 7,  // 最大存储轮次
+        max_storage_rounds: 7,   // 最大存储轮次
     };
     // 运行 P2P 网络模拟
     run_p2p_simulation(config);


### PR DESCRIPTION
## Summary
- add a lazy-initialized log file sink that mirrors console output with microsecond timestamps
- initialize logging from the binary entrypoint and route deployment errors through the logger

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d4d51bc9c8832796b1f57657e76fe0