### PR TITLE
Add 40-node AWS configs for instances 1-10

### DIFF
--- a/deployment/aws/instance-1/config.template.json
+++ b/deployment/aws/instance-1/config.template.json
@@ -44,6 +44,171 @@
           "port": 62006
         },
         {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
           "node_id": "S2N1",
           "host": "${INSTANCE2_IP}",
           "port": 62000
@@ -91,6 +256,171 @@
           "node_id": "S1N7",
           "host": "${INSTANCE1_IP}",
           "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
         },
         {
           "node_id": "S2N1",
@@ -142,6 +472,171 @@
           "port": 62006
         },
         {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
           "node_id": "S2N1",
           "host": "${INSTANCE2_IP}",
           "port": 62000
@@ -189,6 +684,171 @@
           "node_id": "S1N7",
           "host": "${INSTANCE1_IP}",
           "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
         },
         {
           "node_id": "S2N1",
@@ -240,6 +900,171 @@
           "port": 62006
         },
         {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
           "node_id": "S2N1",
           "host": "${INSTANCE2_IP}",
           "port": 62000
@@ -289,6 +1114,171 @@
           "port": 62006
         },
         {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
           "node_id": "S2N1",
           "host": "${INSTANCE2_IP}",
           "port": 62000
@@ -336,6 +1326,7233 @@
           "node_id": "S1N6",
           "host": "${INSTANCE1_IP}",
           "port": 62005
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N40",
+          "host": "${INSTANCE1_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S1N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S1N2",
+          "host": "${INSTANCE1_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S1N3",
+          "host": "${INSTANCE1_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S1N4",
+          "host": "${INSTANCE1_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S1N5",
+          "host": "${INSTANCE1_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S1N6",
+          "host": "${INSTANCE1_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S1N7",
+          "host": "${INSTANCE1_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S1N8",
+          "host": "${INSTANCE1_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S1N9",
+          "host": "${INSTANCE1_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S1N10",
+          "host": "${INSTANCE1_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S1N11",
+          "host": "${INSTANCE1_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S1N12",
+          "host": "${INSTANCE1_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S1N13",
+          "host": "${INSTANCE1_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S1N14",
+          "host": "${INSTANCE1_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S1N15",
+          "host": "${INSTANCE1_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S1N16",
+          "host": "${INSTANCE1_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S1N17",
+          "host": "${INSTANCE1_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S1N18",
+          "host": "${INSTANCE1_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S1N19",
+          "host": "${INSTANCE1_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S1N20",
+          "host": "${INSTANCE1_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S1N21",
+          "host": "${INSTANCE1_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S1N22",
+          "host": "${INSTANCE1_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S1N23",
+          "host": "${INSTANCE1_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S1N24",
+          "host": "${INSTANCE1_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S1N25",
+          "host": "${INSTANCE1_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S1N26",
+          "host": "${INSTANCE1_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S1N27",
+          "host": "${INSTANCE1_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S1N28",
+          "host": "${INSTANCE1_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S1N29",
+          "host": "${INSTANCE1_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S1N30",
+          "host": "${INSTANCE1_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S1N31",
+          "host": "${INSTANCE1_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S1N32",
+          "host": "${INSTANCE1_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S1N33",
+          "host": "${INSTANCE1_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S1N34",
+          "host": "${INSTANCE1_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S1N35",
+          "host": "${INSTANCE1_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S1N36",
+          "host": "${INSTANCE1_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S1N37",
+          "host": "${INSTANCE1_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S1N38",
+          "host": "${INSTANCE1_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S1N39",
+          "host": "${INSTANCE1_IP}",
+          "port": 62038
         },
         {
           "node_id": "S2N1",

--- a/deployment/aws/instance-10/config.template.json
+++ b/deployment/aws/instance-10/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S10N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N40",
+          "host": "${INSTANCE10_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S10N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N2",
+          "host": "${INSTANCE10_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S10N3",
+          "host": "${INSTANCE10_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S10N4",
+          "host": "${INSTANCE10_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S10N5",
+          "host": "${INSTANCE10_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S10N6",
+          "host": "${INSTANCE10_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S10N7",
+          "host": "${INSTANCE10_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S10N8",
+          "host": "${INSTANCE10_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S10N9",
+          "host": "${INSTANCE10_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S10N10",
+          "host": "${INSTANCE10_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S10N11",
+          "host": "${INSTANCE10_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S10N12",
+          "host": "${INSTANCE10_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S10N13",
+          "host": "${INSTANCE10_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S10N14",
+          "host": "${INSTANCE10_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S10N15",
+          "host": "${INSTANCE10_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S10N16",
+          "host": "${INSTANCE10_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S10N17",
+          "host": "${INSTANCE10_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S10N18",
+          "host": "${INSTANCE10_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S10N19",
+          "host": "${INSTANCE10_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S10N20",
+          "host": "${INSTANCE10_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S10N21",
+          "host": "${INSTANCE10_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S10N22",
+          "host": "${INSTANCE10_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S10N23",
+          "host": "${INSTANCE10_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S10N24",
+          "host": "${INSTANCE10_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S10N25",
+          "host": "${INSTANCE10_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S10N26",
+          "host": "${INSTANCE10_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S10N27",
+          "host": "${INSTANCE10_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S10N28",
+          "host": "${INSTANCE10_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S10N29",
+          "host": "${INSTANCE10_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S10N30",
+          "host": "${INSTANCE10_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S10N31",
+          "host": "${INSTANCE10_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S10N32",
+          "host": "${INSTANCE10_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S10N33",
+          "host": "${INSTANCE10_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S10N34",
+          "host": "${INSTANCE10_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S10N35",
+          "host": "${INSTANCE10_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S10N36",
+          "host": "${INSTANCE10_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S10N37",
+          "host": "${INSTANCE10_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S10N38",
+          "host": "${INSTANCE10_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S10N39",
+          "host": "${INSTANCE10_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U10",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE10_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-2/config.template.json
+++ b/deployment/aws/instance-2/config.template.json
@@ -44,6 +44,171 @@
           "port": 62006
         },
         {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
           "node_id": "S1N1",
           "host": "${INSTANCE1_IP}",
           "port": 62000
@@ -91,6 +256,171 @@
           "node_id": "S2N7",
           "host": "${INSTANCE2_IP}",
           "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
         },
         {
           "node_id": "S1N1",
@@ -142,6 +472,171 @@
           "port": 62006
         },
         {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
           "node_id": "S1N1",
           "host": "${INSTANCE1_IP}",
           "port": 62000
@@ -189,6 +684,171 @@
           "node_id": "S2N7",
           "host": "${INSTANCE2_IP}",
           "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
         },
         {
           "node_id": "S1N1",
@@ -240,6 +900,171 @@
           "port": 62006
         },
         {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
           "node_id": "S1N1",
           "host": "${INSTANCE1_IP}",
           "port": 62000
@@ -289,6 +1114,171 @@
           "port": 62006
         },
         {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
           "node_id": "S1N1",
           "host": "${INSTANCE1_IP}",
           "port": 62000
@@ -336,6 +1326,7233 @@
           "node_id": "S2N6",
           "host": "${INSTANCE2_IP}",
           "port": 62005
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N40",
+          "host": "${INSTANCE2_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S2N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N2",
+          "host": "${INSTANCE2_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S2N3",
+          "host": "${INSTANCE2_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S2N4",
+          "host": "${INSTANCE2_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S2N5",
+          "host": "${INSTANCE2_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S2N6",
+          "host": "${INSTANCE2_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S2N7",
+          "host": "${INSTANCE2_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S2N8",
+          "host": "${INSTANCE2_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S2N9",
+          "host": "${INSTANCE2_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S2N10",
+          "host": "${INSTANCE2_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S2N11",
+          "host": "${INSTANCE2_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S2N12",
+          "host": "${INSTANCE2_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S2N13",
+          "host": "${INSTANCE2_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S2N14",
+          "host": "${INSTANCE2_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S2N15",
+          "host": "${INSTANCE2_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S2N16",
+          "host": "${INSTANCE2_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S2N17",
+          "host": "${INSTANCE2_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S2N18",
+          "host": "${INSTANCE2_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S2N19",
+          "host": "${INSTANCE2_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S2N20",
+          "host": "${INSTANCE2_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S2N21",
+          "host": "${INSTANCE2_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S2N22",
+          "host": "${INSTANCE2_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S2N23",
+          "host": "${INSTANCE2_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S2N24",
+          "host": "${INSTANCE2_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S2N25",
+          "host": "${INSTANCE2_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S2N26",
+          "host": "${INSTANCE2_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S2N27",
+          "host": "${INSTANCE2_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S2N28",
+          "host": "${INSTANCE2_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S2N29",
+          "host": "${INSTANCE2_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S2N30",
+          "host": "${INSTANCE2_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S2N31",
+          "host": "${INSTANCE2_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S2N32",
+          "host": "${INSTANCE2_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S2N33",
+          "host": "${INSTANCE2_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S2N34",
+          "host": "${INSTANCE2_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S2N35",
+          "host": "${INSTANCE2_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S2N36",
+          "host": "${INSTANCE2_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S2N37",
+          "host": "${INSTANCE2_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S2N38",
+          "host": "${INSTANCE2_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S2N39",
+          "host": "${INSTANCE2_IP}",
+          "port": 62038
         },
         {
           "node_id": "S1N1",

--- a/deployment/aws/instance-3/config.template.json
+++ b/deployment/aws/instance-3/config.template.json
@@ -44,6 +44,171 @@
           "port": 62006
         },
         {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
           "node_id": "S1N1",
           "host": "${INSTANCE1_IP}",
           "port": 62000
@@ -91,6 +256,171 @@
           "node_id": "S3N7",
           "host": "${INSTANCE3_IP}",
           "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
         },
         {
           "node_id": "S1N1",
@@ -142,6 +472,171 @@
           "port": 62006
         },
         {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
           "node_id": "S1N1",
           "host": "${INSTANCE1_IP}",
           "port": 62000
@@ -189,6 +684,171 @@
           "node_id": "S3N7",
           "host": "${INSTANCE3_IP}",
           "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
         },
         {
           "node_id": "S1N1",
@@ -240,6 +900,171 @@
           "port": 62006
         },
         {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
           "node_id": "S1N1",
           "host": "${INSTANCE1_IP}",
           "port": 62000
@@ -289,6 +1114,171 @@
           "port": 62006
         },
         {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
           "node_id": "S1N1",
           "host": "${INSTANCE1_IP}",
           "port": 62000
@@ -336,6 +1326,7233 @@
           "node_id": "S3N6",
           "host": "${INSTANCE3_IP}",
           "port": 62005
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N40",
+          "host": "${INSTANCE3_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S1N1",
+          "host": "${INSTANCE1_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S3N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N2",
+          "host": "${INSTANCE3_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S3N3",
+          "host": "${INSTANCE3_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S3N4",
+          "host": "${INSTANCE3_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S3N5",
+          "host": "${INSTANCE3_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S3N6",
+          "host": "${INSTANCE3_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S3N7",
+          "host": "${INSTANCE3_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S3N8",
+          "host": "${INSTANCE3_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S3N9",
+          "host": "${INSTANCE3_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S3N10",
+          "host": "${INSTANCE3_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S3N11",
+          "host": "${INSTANCE3_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S3N12",
+          "host": "${INSTANCE3_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S3N13",
+          "host": "${INSTANCE3_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S3N14",
+          "host": "${INSTANCE3_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S3N15",
+          "host": "${INSTANCE3_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S3N16",
+          "host": "${INSTANCE3_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S3N17",
+          "host": "${INSTANCE3_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S3N18",
+          "host": "${INSTANCE3_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S3N19",
+          "host": "${INSTANCE3_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S3N20",
+          "host": "${INSTANCE3_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S3N21",
+          "host": "${INSTANCE3_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S3N22",
+          "host": "${INSTANCE3_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S3N23",
+          "host": "${INSTANCE3_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S3N24",
+          "host": "${INSTANCE3_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S3N25",
+          "host": "${INSTANCE3_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S3N26",
+          "host": "${INSTANCE3_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S3N27",
+          "host": "${INSTANCE3_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S3N28",
+          "host": "${INSTANCE3_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S3N29",
+          "host": "${INSTANCE3_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S3N30",
+          "host": "${INSTANCE3_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S3N31",
+          "host": "${INSTANCE3_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S3N32",
+          "host": "${INSTANCE3_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S3N33",
+          "host": "${INSTANCE3_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S3N34",
+          "host": "${INSTANCE3_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S3N35",
+          "host": "${INSTANCE3_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S3N36",
+          "host": "${INSTANCE3_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S3N37",
+          "host": "${INSTANCE3_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S3N38",
+          "host": "${INSTANCE3_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S3N39",
+          "host": "${INSTANCE3_IP}",
+          "port": 62038
         },
         {
           "node_id": "S1N1",

--- a/deployment/aws/instance-4/config.template.json
+++ b/deployment/aws/instance-4/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S4N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N40",
+          "host": "${INSTANCE4_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S4N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N2",
+          "host": "${INSTANCE4_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S4N3",
+          "host": "${INSTANCE4_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S4N4",
+          "host": "${INSTANCE4_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S4N5",
+          "host": "${INSTANCE4_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S4N6",
+          "host": "${INSTANCE4_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S4N7",
+          "host": "${INSTANCE4_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S4N8",
+          "host": "${INSTANCE4_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S4N9",
+          "host": "${INSTANCE4_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S4N10",
+          "host": "${INSTANCE4_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S4N11",
+          "host": "${INSTANCE4_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S4N12",
+          "host": "${INSTANCE4_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S4N13",
+          "host": "${INSTANCE4_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S4N14",
+          "host": "${INSTANCE4_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S4N15",
+          "host": "${INSTANCE4_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S4N16",
+          "host": "${INSTANCE4_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S4N17",
+          "host": "${INSTANCE4_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S4N18",
+          "host": "${INSTANCE4_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S4N19",
+          "host": "${INSTANCE4_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S4N20",
+          "host": "${INSTANCE4_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S4N21",
+          "host": "${INSTANCE4_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S4N22",
+          "host": "${INSTANCE4_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S4N23",
+          "host": "${INSTANCE4_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S4N24",
+          "host": "${INSTANCE4_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S4N25",
+          "host": "${INSTANCE4_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S4N26",
+          "host": "${INSTANCE4_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S4N27",
+          "host": "${INSTANCE4_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S4N28",
+          "host": "${INSTANCE4_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S4N29",
+          "host": "${INSTANCE4_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S4N30",
+          "host": "${INSTANCE4_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S4N31",
+          "host": "${INSTANCE4_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S4N32",
+          "host": "${INSTANCE4_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S4N33",
+          "host": "${INSTANCE4_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S4N34",
+          "host": "${INSTANCE4_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S4N35",
+          "host": "${INSTANCE4_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S4N36",
+          "host": "${INSTANCE4_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S4N37",
+          "host": "${INSTANCE4_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S4N38",
+          "host": "${INSTANCE4_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S4N39",
+          "host": "${INSTANCE4_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S2N1",
+          "host": "${INSTANCE2_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U4",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE4_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-5/config.template.json
+++ b/deployment/aws/instance-5/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S5N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N40",
+          "host": "${INSTANCE5_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S5N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N2",
+          "host": "${INSTANCE5_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S5N3",
+          "host": "${INSTANCE5_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S5N4",
+          "host": "${INSTANCE5_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S5N5",
+          "host": "${INSTANCE5_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S5N6",
+          "host": "${INSTANCE5_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S5N7",
+          "host": "${INSTANCE5_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S5N8",
+          "host": "${INSTANCE5_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S5N9",
+          "host": "${INSTANCE5_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S5N10",
+          "host": "${INSTANCE5_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S5N11",
+          "host": "${INSTANCE5_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S5N12",
+          "host": "${INSTANCE5_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S5N13",
+          "host": "${INSTANCE5_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S5N14",
+          "host": "${INSTANCE5_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S5N15",
+          "host": "${INSTANCE5_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S5N16",
+          "host": "${INSTANCE5_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S5N17",
+          "host": "${INSTANCE5_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S5N18",
+          "host": "${INSTANCE5_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S5N19",
+          "host": "${INSTANCE5_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S5N20",
+          "host": "${INSTANCE5_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S5N21",
+          "host": "${INSTANCE5_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S5N22",
+          "host": "${INSTANCE5_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S5N23",
+          "host": "${INSTANCE5_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S5N24",
+          "host": "${INSTANCE5_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S5N25",
+          "host": "${INSTANCE5_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S5N26",
+          "host": "${INSTANCE5_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S5N27",
+          "host": "${INSTANCE5_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S5N28",
+          "host": "${INSTANCE5_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S5N29",
+          "host": "${INSTANCE5_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S5N30",
+          "host": "${INSTANCE5_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S5N31",
+          "host": "${INSTANCE5_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S5N32",
+          "host": "${INSTANCE5_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S5N33",
+          "host": "${INSTANCE5_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S5N34",
+          "host": "${INSTANCE5_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S5N35",
+          "host": "${INSTANCE5_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S5N36",
+          "host": "${INSTANCE5_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S5N37",
+          "host": "${INSTANCE5_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S5N38",
+          "host": "${INSTANCE5_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S5N39",
+          "host": "${INSTANCE5_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S3N1",
+          "host": "${INSTANCE3_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U5",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE5_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-6/config.template.json
+++ b/deployment/aws/instance-6/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S6N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N40",
+          "host": "${INSTANCE6_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S6N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N2",
+          "host": "${INSTANCE6_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S6N3",
+          "host": "${INSTANCE6_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S6N4",
+          "host": "${INSTANCE6_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S6N5",
+          "host": "${INSTANCE6_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S6N6",
+          "host": "${INSTANCE6_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S6N7",
+          "host": "${INSTANCE6_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S6N8",
+          "host": "${INSTANCE6_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S6N9",
+          "host": "${INSTANCE6_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S6N10",
+          "host": "${INSTANCE6_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S6N11",
+          "host": "${INSTANCE6_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S6N12",
+          "host": "${INSTANCE6_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S6N13",
+          "host": "${INSTANCE6_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S6N14",
+          "host": "${INSTANCE6_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S6N15",
+          "host": "${INSTANCE6_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S6N16",
+          "host": "${INSTANCE6_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S6N17",
+          "host": "${INSTANCE6_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S6N18",
+          "host": "${INSTANCE6_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S6N19",
+          "host": "${INSTANCE6_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S6N20",
+          "host": "${INSTANCE6_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S6N21",
+          "host": "${INSTANCE6_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S6N22",
+          "host": "${INSTANCE6_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S6N23",
+          "host": "${INSTANCE6_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S6N24",
+          "host": "${INSTANCE6_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S6N25",
+          "host": "${INSTANCE6_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S6N26",
+          "host": "${INSTANCE6_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S6N27",
+          "host": "${INSTANCE6_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S6N28",
+          "host": "${INSTANCE6_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S6N29",
+          "host": "${INSTANCE6_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S6N30",
+          "host": "${INSTANCE6_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S6N31",
+          "host": "${INSTANCE6_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S6N32",
+          "host": "${INSTANCE6_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S6N33",
+          "host": "${INSTANCE6_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S6N34",
+          "host": "${INSTANCE6_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S6N35",
+          "host": "${INSTANCE6_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S6N36",
+          "host": "${INSTANCE6_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S6N37",
+          "host": "${INSTANCE6_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S6N38",
+          "host": "${INSTANCE6_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S6N39",
+          "host": "${INSTANCE6_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S4N1",
+          "host": "${INSTANCE4_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U6",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE6_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-7/config.template.json
+++ b/deployment/aws/instance-7/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S7N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N40",
+          "host": "${INSTANCE7_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S7N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N2",
+          "host": "${INSTANCE7_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S7N3",
+          "host": "${INSTANCE7_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S7N4",
+          "host": "${INSTANCE7_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S7N5",
+          "host": "${INSTANCE7_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S7N6",
+          "host": "${INSTANCE7_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S7N7",
+          "host": "${INSTANCE7_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S7N8",
+          "host": "${INSTANCE7_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S7N9",
+          "host": "${INSTANCE7_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S7N10",
+          "host": "${INSTANCE7_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S7N11",
+          "host": "${INSTANCE7_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S7N12",
+          "host": "${INSTANCE7_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S7N13",
+          "host": "${INSTANCE7_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S7N14",
+          "host": "${INSTANCE7_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S7N15",
+          "host": "${INSTANCE7_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S7N16",
+          "host": "${INSTANCE7_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S7N17",
+          "host": "${INSTANCE7_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S7N18",
+          "host": "${INSTANCE7_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S7N19",
+          "host": "${INSTANCE7_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S7N20",
+          "host": "${INSTANCE7_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S7N21",
+          "host": "${INSTANCE7_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S7N22",
+          "host": "${INSTANCE7_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S7N23",
+          "host": "${INSTANCE7_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S7N24",
+          "host": "${INSTANCE7_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S7N25",
+          "host": "${INSTANCE7_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S7N26",
+          "host": "${INSTANCE7_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S7N27",
+          "host": "${INSTANCE7_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S7N28",
+          "host": "${INSTANCE7_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S7N29",
+          "host": "${INSTANCE7_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S7N30",
+          "host": "${INSTANCE7_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S7N31",
+          "host": "${INSTANCE7_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S7N32",
+          "host": "${INSTANCE7_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S7N33",
+          "host": "${INSTANCE7_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S7N34",
+          "host": "${INSTANCE7_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S7N35",
+          "host": "${INSTANCE7_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S7N36",
+          "host": "${INSTANCE7_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S7N37",
+          "host": "${INSTANCE7_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S7N38",
+          "host": "${INSTANCE7_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S7N39",
+          "host": "${INSTANCE7_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S5N1",
+          "host": "${INSTANCE5_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U7",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE7_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-8/config.template.json
+++ b/deployment/aws/instance-8/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S8N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N40",
+          "host": "${INSTANCE8_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S8N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N2",
+          "host": "${INSTANCE8_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S8N3",
+          "host": "${INSTANCE8_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S8N4",
+          "host": "${INSTANCE8_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S8N5",
+          "host": "${INSTANCE8_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S8N6",
+          "host": "${INSTANCE8_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S8N7",
+          "host": "${INSTANCE8_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S8N8",
+          "host": "${INSTANCE8_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S8N9",
+          "host": "${INSTANCE8_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S8N10",
+          "host": "${INSTANCE8_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S8N11",
+          "host": "${INSTANCE8_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S8N12",
+          "host": "${INSTANCE8_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S8N13",
+          "host": "${INSTANCE8_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S8N14",
+          "host": "${INSTANCE8_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S8N15",
+          "host": "${INSTANCE8_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S8N16",
+          "host": "${INSTANCE8_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S8N17",
+          "host": "${INSTANCE8_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S8N18",
+          "host": "${INSTANCE8_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S8N19",
+          "host": "${INSTANCE8_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S8N20",
+          "host": "${INSTANCE8_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S8N21",
+          "host": "${INSTANCE8_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S8N22",
+          "host": "${INSTANCE8_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S8N23",
+          "host": "${INSTANCE8_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S8N24",
+          "host": "${INSTANCE8_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S8N25",
+          "host": "${INSTANCE8_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S8N26",
+          "host": "${INSTANCE8_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S8N27",
+          "host": "${INSTANCE8_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S8N28",
+          "host": "${INSTANCE8_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S8N29",
+          "host": "${INSTANCE8_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S8N30",
+          "host": "${INSTANCE8_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S8N31",
+          "host": "${INSTANCE8_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S8N32",
+          "host": "${INSTANCE8_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S8N33",
+          "host": "${INSTANCE8_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S8N34",
+          "host": "${INSTANCE8_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S8N35",
+          "host": "${INSTANCE8_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S8N36",
+          "host": "${INSTANCE8_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S8N37",
+          "host": "${INSTANCE8_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S8N38",
+          "host": "${INSTANCE8_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S8N39",
+          "host": "${INSTANCE8_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S6N1",
+          "host": "${INSTANCE6_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U8",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE8_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-9/config.template.json
+++ b/deployment/aws/instance-9/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S9N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N40",
+          "host": "${INSTANCE9_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S9N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S9N2",
+          "host": "${INSTANCE9_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S9N3",
+          "host": "${INSTANCE9_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S9N4",
+          "host": "${INSTANCE9_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S9N5",
+          "host": "${INSTANCE9_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S9N6",
+          "host": "${INSTANCE9_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S9N7",
+          "host": "${INSTANCE9_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S9N8",
+          "host": "${INSTANCE9_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S9N9",
+          "host": "${INSTANCE9_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S9N10",
+          "host": "${INSTANCE9_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S9N11",
+          "host": "${INSTANCE9_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S9N12",
+          "host": "${INSTANCE9_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S9N13",
+          "host": "${INSTANCE9_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S9N14",
+          "host": "${INSTANCE9_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S9N15",
+          "host": "${INSTANCE9_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S9N16",
+          "host": "${INSTANCE9_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S9N17",
+          "host": "${INSTANCE9_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S9N18",
+          "host": "${INSTANCE9_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S9N19",
+          "host": "${INSTANCE9_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S9N20",
+          "host": "${INSTANCE9_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S9N21",
+          "host": "${INSTANCE9_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S9N22",
+          "host": "${INSTANCE9_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S9N23",
+          "host": "${INSTANCE9_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S9N24",
+          "host": "${INSTANCE9_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S9N25",
+          "host": "${INSTANCE9_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S9N26",
+          "host": "${INSTANCE9_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S9N27",
+          "host": "${INSTANCE9_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S9N28",
+          "host": "${INSTANCE9_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S9N29",
+          "host": "${INSTANCE9_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S9N30",
+          "host": "${INSTANCE9_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S9N31",
+          "host": "${INSTANCE9_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S9N32",
+          "host": "${INSTANCE9_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S9N33",
+          "host": "${INSTANCE9_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S9N34",
+          "host": "${INSTANCE9_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S9N35",
+          "host": "${INSTANCE9_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S9N36",
+          "host": "${INSTANCE9_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S9N37",
+          "host": "${INSTANCE9_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S9N38",
+          "host": "${INSTANCE9_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S9N39",
+          "host": "${INSTANCE9_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S7N1",
+          "host": "${INSTANCE7_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S8N1",
+          "host": "${INSTANCE8_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U9",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE9_IP}:62000"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- expand the AWS instance 1-3 templates to define 40 storage nodes while keeping existing peer wiring
- add config templates for instances 4-10 with 40 storage nodes and static peers to adjacent gateways

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d901be6f388327ab3b970012c49382