### PR TITLE
Add AWS config templates for instances 11-20

### DIFF
--- a/deployment/aws/instance-11/config.template.json
+++ b/deployment/aws/instance-11/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S11N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N40",
+          "host": "${INSTANCE11_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S11N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N2",
+          "host": "${INSTANCE11_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S11N3",
+          "host": "${INSTANCE11_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S11N4",
+          "host": "${INSTANCE11_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S11N5",
+          "host": "${INSTANCE11_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S11N6",
+          "host": "${INSTANCE11_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S11N7",
+          "host": "${INSTANCE11_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S11N8",
+          "host": "${INSTANCE11_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S11N9",
+          "host": "${INSTANCE11_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S11N10",
+          "host": "${INSTANCE11_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S11N11",
+          "host": "${INSTANCE11_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S11N12",
+          "host": "${INSTANCE11_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S11N13",
+          "host": "${INSTANCE11_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S11N14",
+          "host": "${INSTANCE11_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S11N15",
+          "host": "${INSTANCE11_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S11N16",
+          "host": "${INSTANCE11_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S11N17",
+          "host": "${INSTANCE11_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S11N18",
+          "host": "${INSTANCE11_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S11N19",
+          "host": "${INSTANCE11_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S11N20",
+          "host": "${INSTANCE11_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S11N21",
+          "host": "${INSTANCE11_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S11N22",
+          "host": "${INSTANCE11_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S11N23",
+          "host": "${INSTANCE11_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S11N24",
+          "host": "${INSTANCE11_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S11N25",
+          "host": "${INSTANCE11_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S11N26",
+          "host": "${INSTANCE11_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S11N27",
+          "host": "${INSTANCE11_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S11N28",
+          "host": "${INSTANCE11_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S11N29",
+          "host": "${INSTANCE11_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S11N30",
+          "host": "${INSTANCE11_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S11N31",
+          "host": "${INSTANCE11_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S11N32",
+          "host": "${INSTANCE11_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S11N33",
+          "host": "${INSTANCE11_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S11N34",
+          "host": "${INSTANCE11_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S11N35",
+          "host": "${INSTANCE11_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S11N36",
+          "host": "${INSTANCE11_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S11N37",
+          "host": "${INSTANCE11_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S11N38",
+          "host": "${INSTANCE11_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S11N39",
+          "host": "${INSTANCE11_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S9N1",
+          "host": "${INSTANCE9_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U11",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE11_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-12/config.template.json
+++ b/deployment/aws/instance-12/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S12N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N40",
+          "host": "${INSTANCE12_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S12N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N2",
+          "host": "${INSTANCE12_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S12N3",
+          "host": "${INSTANCE12_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S12N4",
+          "host": "${INSTANCE12_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S12N5",
+          "host": "${INSTANCE12_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S12N6",
+          "host": "${INSTANCE12_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S12N7",
+          "host": "${INSTANCE12_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S12N8",
+          "host": "${INSTANCE12_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S12N9",
+          "host": "${INSTANCE12_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S12N10",
+          "host": "${INSTANCE12_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S12N11",
+          "host": "${INSTANCE12_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S12N12",
+          "host": "${INSTANCE12_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S12N13",
+          "host": "${INSTANCE12_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S12N14",
+          "host": "${INSTANCE12_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S12N15",
+          "host": "${INSTANCE12_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S12N16",
+          "host": "${INSTANCE12_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S12N17",
+          "host": "${INSTANCE12_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S12N18",
+          "host": "${INSTANCE12_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S12N19",
+          "host": "${INSTANCE12_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S12N20",
+          "host": "${INSTANCE12_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S12N21",
+          "host": "${INSTANCE12_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S12N22",
+          "host": "${INSTANCE12_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S12N23",
+          "host": "${INSTANCE12_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S12N24",
+          "host": "${INSTANCE12_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S12N25",
+          "host": "${INSTANCE12_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S12N26",
+          "host": "${INSTANCE12_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S12N27",
+          "host": "${INSTANCE12_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S12N28",
+          "host": "${INSTANCE12_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S12N29",
+          "host": "${INSTANCE12_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S12N30",
+          "host": "${INSTANCE12_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S12N31",
+          "host": "${INSTANCE12_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S12N32",
+          "host": "${INSTANCE12_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S12N33",
+          "host": "${INSTANCE12_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S12N34",
+          "host": "${INSTANCE12_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S12N35",
+          "host": "${INSTANCE12_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S12N36",
+          "host": "${INSTANCE12_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S12N37",
+          "host": "${INSTANCE12_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S12N38",
+          "host": "${INSTANCE12_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S12N39",
+          "host": "${INSTANCE12_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S10N1",
+          "host": "${INSTANCE10_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U12",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE12_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-13/config.template.json
+++ b/deployment/aws/instance-13/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S13N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N40",
+          "host": "${INSTANCE13_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S13N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N2",
+          "host": "${INSTANCE13_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S13N3",
+          "host": "${INSTANCE13_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S13N4",
+          "host": "${INSTANCE13_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S13N5",
+          "host": "${INSTANCE13_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S13N6",
+          "host": "${INSTANCE13_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S13N7",
+          "host": "${INSTANCE13_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S13N8",
+          "host": "${INSTANCE13_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S13N9",
+          "host": "${INSTANCE13_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S13N10",
+          "host": "${INSTANCE13_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S13N11",
+          "host": "${INSTANCE13_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S13N12",
+          "host": "${INSTANCE13_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S13N13",
+          "host": "${INSTANCE13_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S13N14",
+          "host": "${INSTANCE13_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S13N15",
+          "host": "${INSTANCE13_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S13N16",
+          "host": "${INSTANCE13_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S13N17",
+          "host": "${INSTANCE13_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S13N18",
+          "host": "${INSTANCE13_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S13N19",
+          "host": "${INSTANCE13_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S13N20",
+          "host": "${INSTANCE13_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S13N21",
+          "host": "${INSTANCE13_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S13N22",
+          "host": "${INSTANCE13_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S13N23",
+          "host": "${INSTANCE13_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S13N24",
+          "host": "${INSTANCE13_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S13N25",
+          "host": "${INSTANCE13_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S13N26",
+          "host": "${INSTANCE13_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S13N27",
+          "host": "${INSTANCE13_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S13N28",
+          "host": "${INSTANCE13_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S13N29",
+          "host": "${INSTANCE13_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S13N30",
+          "host": "${INSTANCE13_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S13N31",
+          "host": "${INSTANCE13_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S13N32",
+          "host": "${INSTANCE13_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S13N33",
+          "host": "${INSTANCE13_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S13N34",
+          "host": "${INSTANCE13_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S13N35",
+          "host": "${INSTANCE13_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S13N36",
+          "host": "${INSTANCE13_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S13N37",
+          "host": "${INSTANCE13_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S13N38",
+          "host": "${INSTANCE13_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S13N39",
+          "host": "${INSTANCE13_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S11N1",
+          "host": "${INSTANCE11_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U13",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE13_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-14/config.template.json
+++ b/deployment/aws/instance-14/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S14N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N40",
+          "host": "${INSTANCE14_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S14N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N2",
+          "host": "${INSTANCE14_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S14N3",
+          "host": "${INSTANCE14_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S14N4",
+          "host": "${INSTANCE14_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S14N5",
+          "host": "${INSTANCE14_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S14N6",
+          "host": "${INSTANCE14_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S14N7",
+          "host": "${INSTANCE14_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S14N8",
+          "host": "${INSTANCE14_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S14N9",
+          "host": "${INSTANCE14_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S14N10",
+          "host": "${INSTANCE14_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S14N11",
+          "host": "${INSTANCE14_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S14N12",
+          "host": "${INSTANCE14_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S14N13",
+          "host": "${INSTANCE14_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S14N14",
+          "host": "${INSTANCE14_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S14N15",
+          "host": "${INSTANCE14_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S14N16",
+          "host": "${INSTANCE14_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S14N17",
+          "host": "${INSTANCE14_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S14N18",
+          "host": "${INSTANCE14_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S14N19",
+          "host": "${INSTANCE14_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S14N20",
+          "host": "${INSTANCE14_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S14N21",
+          "host": "${INSTANCE14_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S14N22",
+          "host": "${INSTANCE14_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S14N23",
+          "host": "${INSTANCE14_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S14N24",
+          "host": "${INSTANCE14_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S14N25",
+          "host": "${INSTANCE14_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S14N26",
+          "host": "${INSTANCE14_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S14N27",
+          "host": "${INSTANCE14_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S14N28",
+          "host": "${INSTANCE14_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S14N29",
+          "host": "${INSTANCE14_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S14N30",
+          "host": "${INSTANCE14_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S14N31",
+          "host": "${INSTANCE14_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S14N32",
+          "host": "${INSTANCE14_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S14N33",
+          "host": "${INSTANCE14_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S14N34",
+          "host": "${INSTANCE14_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S14N35",
+          "host": "${INSTANCE14_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S14N36",
+          "host": "${INSTANCE14_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S14N37",
+          "host": "${INSTANCE14_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S14N38",
+          "host": "${INSTANCE14_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S14N39",
+          "host": "${INSTANCE14_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S12N1",
+          "host": "${INSTANCE12_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U14",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE14_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-15/config.template.json
+++ b/deployment/aws/instance-15/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S15N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N40",
+          "host": "${INSTANCE15_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S15N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N2",
+          "host": "${INSTANCE15_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S15N3",
+          "host": "${INSTANCE15_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S15N4",
+          "host": "${INSTANCE15_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S15N5",
+          "host": "${INSTANCE15_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S15N6",
+          "host": "${INSTANCE15_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S15N7",
+          "host": "${INSTANCE15_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S15N8",
+          "host": "${INSTANCE15_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S15N9",
+          "host": "${INSTANCE15_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S15N10",
+          "host": "${INSTANCE15_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S15N11",
+          "host": "${INSTANCE15_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S15N12",
+          "host": "${INSTANCE15_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S15N13",
+          "host": "${INSTANCE15_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S15N14",
+          "host": "${INSTANCE15_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S15N15",
+          "host": "${INSTANCE15_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S15N16",
+          "host": "${INSTANCE15_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S15N17",
+          "host": "${INSTANCE15_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S15N18",
+          "host": "${INSTANCE15_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S15N19",
+          "host": "${INSTANCE15_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S15N20",
+          "host": "${INSTANCE15_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S15N21",
+          "host": "${INSTANCE15_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S15N22",
+          "host": "${INSTANCE15_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S15N23",
+          "host": "${INSTANCE15_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S15N24",
+          "host": "${INSTANCE15_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S15N25",
+          "host": "${INSTANCE15_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S15N26",
+          "host": "${INSTANCE15_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S15N27",
+          "host": "${INSTANCE15_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S15N28",
+          "host": "${INSTANCE15_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S15N29",
+          "host": "${INSTANCE15_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S15N30",
+          "host": "${INSTANCE15_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S15N31",
+          "host": "${INSTANCE15_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S15N32",
+          "host": "${INSTANCE15_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S15N33",
+          "host": "${INSTANCE15_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S15N34",
+          "host": "${INSTANCE15_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S15N35",
+          "host": "${INSTANCE15_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S15N36",
+          "host": "${INSTANCE15_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S15N37",
+          "host": "${INSTANCE15_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S15N38",
+          "host": "${INSTANCE15_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S15N39",
+          "host": "${INSTANCE15_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S13N1",
+          "host": "${INSTANCE13_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U15",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE15_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-16/config.template.json
+++ b/deployment/aws/instance-16/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S16N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N40",
+          "host": "${INSTANCE16_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S16N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N2",
+          "host": "${INSTANCE16_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S16N3",
+          "host": "${INSTANCE16_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S16N4",
+          "host": "${INSTANCE16_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S16N5",
+          "host": "${INSTANCE16_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S16N6",
+          "host": "${INSTANCE16_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S16N7",
+          "host": "${INSTANCE16_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S16N8",
+          "host": "${INSTANCE16_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S16N9",
+          "host": "${INSTANCE16_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S16N10",
+          "host": "${INSTANCE16_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S16N11",
+          "host": "${INSTANCE16_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S16N12",
+          "host": "${INSTANCE16_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S16N13",
+          "host": "${INSTANCE16_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S16N14",
+          "host": "${INSTANCE16_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S16N15",
+          "host": "${INSTANCE16_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S16N16",
+          "host": "${INSTANCE16_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S16N17",
+          "host": "${INSTANCE16_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S16N18",
+          "host": "${INSTANCE16_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S16N19",
+          "host": "${INSTANCE16_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S16N20",
+          "host": "${INSTANCE16_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S16N21",
+          "host": "${INSTANCE16_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S16N22",
+          "host": "${INSTANCE16_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S16N23",
+          "host": "${INSTANCE16_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S16N24",
+          "host": "${INSTANCE16_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S16N25",
+          "host": "${INSTANCE16_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S16N26",
+          "host": "${INSTANCE16_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S16N27",
+          "host": "${INSTANCE16_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S16N28",
+          "host": "${INSTANCE16_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S16N29",
+          "host": "${INSTANCE16_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S16N30",
+          "host": "${INSTANCE16_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S16N31",
+          "host": "${INSTANCE16_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S16N32",
+          "host": "${INSTANCE16_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S16N33",
+          "host": "${INSTANCE16_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S16N34",
+          "host": "${INSTANCE16_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S16N35",
+          "host": "${INSTANCE16_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S16N36",
+          "host": "${INSTANCE16_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S16N37",
+          "host": "${INSTANCE16_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S16N38",
+          "host": "${INSTANCE16_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S16N39",
+          "host": "${INSTANCE16_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S14N1",
+          "host": "${INSTANCE14_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U16",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE16_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-17/config.template.json
+++ b/deployment/aws/instance-17/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S17N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N40",
+          "host": "${INSTANCE17_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S17N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N2",
+          "host": "${INSTANCE17_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S17N3",
+          "host": "${INSTANCE17_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S17N4",
+          "host": "${INSTANCE17_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S17N5",
+          "host": "${INSTANCE17_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S17N6",
+          "host": "${INSTANCE17_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S17N7",
+          "host": "${INSTANCE17_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S17N8",
+          "host": "${INSTANCE17_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S17N9",
+          "host": "${INSTANCE17_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S17N10",
+          "host": "${INSTANCE17_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S17N11",
+          "host": "${INSTANCE17_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S17N12",
+          "host": "${INSTANCE17_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S17N13",
+          "host": "${INSTANCE17_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S17N14",
+          "host": "${INSTANCE17_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S17N15",
+          "host": "${INSTANCE17_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S17N16",
+          "host": "${INSTANCE17_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S17N17",
+          "host": "${INSTANCE17_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S17N18",
+          "host": "${INSTANCE17_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S17N19",
+          "host": "${INSTANCE17_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S17N20",
+          "host": "${INSTANCE17_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S17N21",
+          "host": "${INSTANCE17_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S17N22",
+          "host": "${INSTANCE17_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S17N23",
+          "host": "${INSTANCE17_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S17N24",
+          "host": "${INSTANCE17_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S17N25",
+          "host": "${INSTANCE17_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S17N26",
+          "host": "${INSTANCE17_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S17N27",
+          "host": "${INSTANCE17_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S17N28",
+          "host": "${INSTANCE17_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S17N29",
+          "host": "${INSTANCE17_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S17N30",
+          "host": "${INSTANCE17_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S17N31",
+          "host": "${INSTANCE17_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S17N32",
+          "host": "${INSTANCE17_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S17N33",
+          "host": "${INSTANCE17_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S17N34",
+          "host": "${INSTANCE17_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S17N35",
+          "host": "${INSTANCE17_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S17N36",
+          "host": "${INSTANCE17_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S17N37",
+          "host": "${INSTANCE17_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S17N38",
+          "host": "${INSTANCE17_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S17N39",
+          "host": "${INSTANCE17_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S15N1",
+          "host": "${INSTANCE15_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U17",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE17_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-18/config.template.json
+++ b/deployment/aws/instance-18/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S18N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N40",
+          "host": "${INSTANCE18_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S18N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N2",
+          "host": "${INSTANCE18_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S18N3",
+          "host": "${INSTANCE18_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S18N4",
+          "host": "${INSTANCE18_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S18N5",
+          "host": "${INSTANCE18_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S18N6",
+          "host": "${INSTANCE18_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S18N7",
+          "host": "${INSTANCE18_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S18N8",
+          "host": "${INSTANCE18_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S18N9",
+          "host": "${INSTANCE18_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S18N10",
+          "host": "${INSTANCE18_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S18N11",
+          "host": "${INSTANCE18_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S18N12",
+          "host": "${INSTANCE18_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S18N13",
+          "host": "${INSTANCE18_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S18N14",
+          "host": "${INSTANCE18_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S18N15",
+          "host": "${INSTANCE18_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S18N16",
+          "host": "${INSTANCE18_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S18N17",
+          "host": "${INSTANCE18_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S18N18",
+          "host": "${INSTANCE18_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S18N19",
+          "host": "${INSTANCE18_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S18N20",
+          "host": "${INSTANCE18_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S18N21",
+          "host": "${INSTANCE18_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S18N22",
+          "host": "${INSTANCE18_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S18N23",
+          "host": "${INSTANCE18_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S18N24",
+          "host": "${INSTANCE18_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S18N25",
+          "host": "${INSTANCE18_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S18N26",
+          "host": "${INSTANCE18_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S18N27",
+          "host": "${INSTANCE18_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S18N28",
+          "host": "${INSTANCE18_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S18N29",
+          "host": "${INSTANCE18_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S18N30",
+          "host": "${INSTANCE18_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S18N31",
+          "host": "${INSTANCE18_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S18N32",
+          "host": "${INSTANCE18_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S18N33",
+          "host": "${INSTANCE18_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S18N34",
+          "host": "${INSTANCE18_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S18N35",
+          "host": "${INSTANCE18_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S18N36",
+          "host": "${INSTANCE18_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S18N37",
+          "host": "${INSTANCE18_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S18N38",
+          "host": "${INSTANCE18_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S18N39",
+          "host": "${INSTANCE18_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S16N1",
+          "host": "${INSTANCE16_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U18",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE18_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-19/config.template.json
+++ b/deployment/aws/instance-19/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S19N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N40",
+          "host": "${INSTANCE19_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S19N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N2",
+          "host": "${INSTANCE19_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S19N3",
+          "host": "${INSTANCE19_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S19N4",
+          "host": "${INSTANCE19_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S19N5",
+          "host": "${INSTANCE19_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S19N6",
+          "host": "${INSTANCE19_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S19N7",
+          "host": "${INSTANCE19_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S19N8",
+          "host": "${INSTANCE19_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S19N9",
+          "host": "${INSTANCE19_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S19N10",
+          "host": "${INSTANCE19_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S19N11",
+          "host": "${INSTANCE19_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S19N12",
+          "host": "${INSTANCE19_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S19N13",
+          "host": "${INSTANCE19_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S19N14",
+          "host": "${INSTANCE19_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S19N15",
+          "host": "${INSTANCE19_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S19N16",
+          "host": "${INSTANCE19_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S19N17",
+          "host": "${INSTANCE19_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S19N18",
+          "host": "${INSTANCE19_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S19N19",
+          "host": "${INSTANCE19_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S19N20",
+          "host": "${INSTANCE19_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S19N21",
+          "host": "${INSTANCE19_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S19N22",
+          "host": "${INSTANCE19_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S19N23",
+          "host": "${INSTANCE19_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S19N24",
+          "host": "${INSTANCE19_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S19N25",
+          "host": "${INSTANCE19_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S19N26",
+          "host": "${INSTANCE19_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S19N27",
+          "host": "${INSTANCE19_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S19N28",
+          "host": "${INSTANCE19_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S19N29",
+          "host": "${INSTANCE19_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S19N30",
+          "host": "${INSTANCE19_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S19N31",
+          "host": "${INSTANCE19_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S19N32",
+          "host": "${INSTANCE19_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S19N33",
+          "host": "${INSTANCE19_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S19N34",
+          "host": "${INSTANCE19_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S19N35",
+          "host": "${INSTANCE19_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S19N36",
+          "host": "${INSTANCE19_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S19N37",
+          "host": "${INSTANCE19_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S19N38",
+          "host": "${INSTANCE19_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S19N39",
+          "host": "${INSTANCE19_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S17N1",
+          "host": "${INSTANCE17_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U19",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE19_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-20/config.template.json
+++ b/deployment/aws/instance-20/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S20N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N40",
+          "host": "${INSTANCE20_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S20N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N2",
+          "host": "${INSTANCE20_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S20N3",
+          "host": "${INSTANCE20_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S20N4",
+          "host": "${INSTANCE20_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S20N5",
+          "host": "${INSTANCE20_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S20N6",
+          "host": "${INSTANCE20_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S20N7",
+          "host": "${INSTANCE20_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S20N8",
+          "host": "${INSTANCE20_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S20N9",
+          "host": "${INSTANCE20_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S20N10",
+          "host": "${INSTANCE20_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S20N11",
+          "host": "${INSTANCE20_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S20N12",
+          "host": "${INSTANCE20_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S20N13",
+          "host": "${INSTANCE20_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S20N14",
+          "host": "${INSTANCE20_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S20N15",
+          "host": "${INSTANCE20_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S20N16",
+          "host": "${INSTANCE20_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S20N17",
+          "host": "${INSTANCE20_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S20N18",
+          "host": "${INSTANCE20_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S20N19",
+          "host": "${INSTANCE20_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S20N20",
+          "host": "${INSTANCE20_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S20N21",
+          "host": "${INSTANCE20_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S20N22",
+          "host": "${INSTANCE20_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S20N23",
+          "host": "${INSTANCE20_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S20N24",
+          "host": "${INSTANCE20_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S20N25",
+          "host": "${INSTANCE20_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S20N26",
+          "host": "${INSTANCE20_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S20N27",
+          "host": "${INSTANCE20_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S20N28",
+          "host": "${INSTANCE20_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S20N29",
+          "host": "${INSTANCE20_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S20N30",
+          "host": "${INSTANCE20_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S20N31",
+          "host": "${INSTANCE20_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S20N32",
+          "host": "${INSTANCE20_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S20N33",
+          "host": "${INSTANCE20_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S20N34",
+          "host": "${INSTANCE20_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S20N35",
+          "host": "${INSTANCE20_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S20N36",
+          "host": "${INSTANCE20_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S20N37",
+          "host": "${INSTANCE20_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S20N38",
+          "host": "${INSTANCE20_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S20N39",
+          "host": "${INSTANCE20_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S18N1",
+          "host": "${INSTANCE18_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U20",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE20_IP}:62000"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add AWS deployment config templates for instances 11 through 20, defining 40 storage nodes and a bootstrap user per instance

## Testing
- python - <<'PY'
import json
for inst in range(11, 21):
    path = f'deployment/aws/instance-{inst}/config.template.json'
    with open(path) as f:
        data = json.load(f)
    assert len(data['nodes']) == 40, inst
    for node in data['nodes']:
        assert len(node['peers']) == 41, (inst, node['node_id'], len(node['peers']))
    assert data['users'][0]['user_id'] == f'U{inst}'
print('ok')
PY

------
https://chatgpt.com/codex/tasks/task_e_68d905468750832794d58984a6ca3fa9