### PR TITLE
Add config templates for AWS instances 21-30

### DIFF
--- a/deployment/aws/instance-21/config.template.json
+++ b/deployment/aws/instance-21/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S21N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N40",
+          "host": "${INSTANCE21_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S21N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N2",
+          "host": "${INSTANCE21_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S21N3",
+          "host": "${INSTANCE21_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S21N4",
+          "host": "${INSTANCE21_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S21N5",
+          "host": "${INSTANCE21_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S21N6",
+          "host": "${INSTANCE21_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S21N7",
+          "host": "${INSTANCE21_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S21N8",
+          "host": "${INSTANCE21_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S21N9",
+          "host": "${INSTANCE21_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S21N10",
+          "host": "${INSTANCE21_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S21N11",
+          "host": "${INSTANCE21_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S21N12",
+          "host": "${INSTANCE21_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S21N13",
+          "host": "${INSTANCE21_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S21N14",
+          "host": "${INSTANCE21_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S21N15",
+          "host": "${INSTANCE21_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S21N16",
+          "host": "${INSTANCE21_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S21N17",
+          "host": "${INSTANCE21_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S21N18",
+          "host": "${INSTANCE21_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S21N19",
+          "host": "${INSTANCE21_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S21N20",
+          "host": "${INSTANCE21_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S21N21",
+          "host": "${INSTANCE21_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S21N22",
+          "host": "${INSTANCE21_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S21N23",
+          "host": "${INSTANCE21_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S21N24",
+          "host": "${INSTANCE21_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S21N25",
+          "host": "${INSTANCE21_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S21N26",
+          "host": "${INSTANCE21_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S21N27",
+          "host": "${INSTANCE21_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S21N28",
+          "host": "${INSTANCE21_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S21N29",
+          "host": "${INSTANCE21_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S21N30",
+          "host": "${INSTANCE21_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S21N31",
+          "host": "${INSTANCE21_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S21N32",
+          "host": "${INSTANCE21_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S21N33",
+          "host": "${INSTANCE21_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S21N34",
+          "host": "${INSTANCE21_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S21N35",
+          "host": "${INSTANCE21_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S21N36",
+          "host": "${INSTANCE21_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S21N37",
+          "host": "${INSTANCE21_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S21N38",
+          "host": "${INSTANCE21_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S21N39",
+          "host": "${INSTANCE21_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S19N1",
+          "host": "${INSTANCE19_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U21",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE21_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-22/config.template.json
+++ b/deployment/aws/instance-22/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S22N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N40",
+          "host": "${INSTANCE22_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S22N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N2",
+          "host": "${INSTANCE22_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S22N3",
+          "host": "${INSTANCE22_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S22N4",
+          "host": "${INSTANCE22_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S22N5",
+          "host": "${INSTANCE22_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S22N6",
+          "host": "${INSTANCE22_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S22N7",
+          "host": "${INSTANCE22_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S22N8",
+          "host": "${INSTANCE22_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S22N9",
+          "host": "${INSTANCE22_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S22N10",
+          "host": "${INSTANCE22_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S22N11",
+          "host": "${INSTANCE22_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S22N12",
+          "host": "${INSTANCE22_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S22N13",
+          "host": "${INSTANCE22_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S22N14",
+          "host": "${INSTANCE22_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S22N15",
+          "host": "${INSTANCE22_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S22N16",
+          "host": "${INSTANCE22_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S22N17",
+          "host": "${INSTANCE22_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S22N18",
+          "host": "${INSTANCE22_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S22N19",
+          "host": "${INSTANCE22_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S22N20",
+          "host": "${INSTANCE22_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S22N21",
+          "host": "${INSTANCE22_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S22N22",
+          "host": "${INSTANCE22_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S22N23",
+          "host": "${INSTANCE22_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S22N24",
+          "host": "${INSTANCE22_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S22N25",
+          "host": "${INSTANCE22_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S22N26",
+          "host": "${INSTANCE22_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S22N27",
+          "host": "${INSTANCE22_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S22N28",
+          "host": "${INSTANCE22_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S22N29",
+          "host": "${INSTANCE22_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S22N30",
+          "host": "${INSTANCE22_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S22N31",
+          "host": "${INSTANCE22_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S22N32",
+          "host": "${INSTANCE22_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S22N33",
+          "host": "${INSTANCE22_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S22N34",
+          "host": "${INSTANCE22_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S22N35",
+          "host": "${INSTANCE22_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S22N36",
+          "host": "${INSTANCE22_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S22N37",
+          "host": "${INSTANCE22_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S22N38",
+          "host": "${INSTANCE22_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S22N39",
+          "host": "${INSTANCE22_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S20N1",
+          "host": "${INSTANCE20_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U22",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE22_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-23/config.template.json
+++ b/deployment/aws/instance-23/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S23N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N40",
+          "host": "${INSTANCE23_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S23N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N2",
+          "host": "${INSTANCE23_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S23N3",
+          "host": "${INSTANCE23_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S23N4",
+          "host": "${INSTANCE23_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S23N5",
+          "host": "${INSTANCE23_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S23N6",
+          "host": "${INSTANCE23_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S23N7",
+          "host": "${INSTANCE23_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S23N8",
+          "host": "${INSTANCE23_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S23N9",
+          "host": "${INSTANCE23_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S23N10",
+          "host": "${INSTANCE23_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S23N11",
+          "host": "${INSTANCE23_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S23N12",
+          "host": "${INSTANCE23_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S23N13",
+          "host": "${INSTANCE23_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S23N14",
+          "host": "${INSTANCE23_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S23N15",
+          "host": "${INSTANCE23_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S23N16",
+          "host": "${INSTANCE23_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S23N17",
+          "host": "${INSTANCE23_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S23N18",
+          "host": "${INSTANCE23_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S23N19",
+          "host": "${INSTANCE23_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S23N20",
+          "host": "${INSTANCE23_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S23N21",
+          "host": "${INSTANCE23_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S23N22",
+          "host": "${INSTANCE23_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S23N23",
+          "host": "${INSTANCE23_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S23N24",
+          "host": "${INSTANCE23_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S23N25",
+          "host": "${INSTANCE23_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S23N26",
+          "host": "${INSTANCE23_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S23N27",
+          "host": "${INSTANCE23_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S23N28",
+          "host": "${INSTANCE23_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S23N29",
+          "host": "${INSTANCE23_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S23N30",
+          "host": "${INSTANCE23_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S23N31",
+          "host": "${INSTANCE23_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S23N32",
+          "host": "${INSTANCE23_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S23N33",
+          "host": "${INSTANCE23_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S23N34",
+          "host": "${INSTANCE23_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S23N35",
+          "host": "${INSTANCE23_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S23N36",
+          "host": "${INSTANCE23_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S23N37",
+          "host": "${INSTANCE23_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S23N38",
+          "host": "${INSTANCE23_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S23N39",
+          "host": "${INSTANCE23_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S21N1",
+          "host": "${INSTANCE21_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U23",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE23_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-24/config.template.json
+++ b/deployment/aws/instance-24/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S24N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N40",
+          "host": "${INSTANCE24_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S24N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N2",
+          "host": "${INSTANCE24_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S24N3",
+          "host": "${INSTANCE24_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S24N4",
+          "host": "${INSTANCE24_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S24N5",
+          "host": "${INSTANCE24_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S24N6",
+          "host": "${INSTANCE24_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S24N7",
+          "host": "${INSTANCE24_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S24N8",
+          "host": "${INSTANCE24_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S24N9",
+          "host": "${INSTANCE24_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S24N10",
+          "host": "${INSTANCE24_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S24N11",
+          "host": "${INSTANCE24_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S24N12",
+          "host": "${INSTANCE24_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S24N13",
+          "host": "${INSTANCE24_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S24N14",
+          "host": "${INSTANCE24_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S24N15",
+          "host": "${INSTANCE24_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S24N16",
+          "host": "${INSTANCE24_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S24N17",
+          "host": "${INSTANCE24_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S24N18",
+          "host": "${INSTANCE24_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S24N19",
+          "host": "${INSTANCE24_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S24N20",
+          "host": "${INSTANCE24_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S24N21",
+          "host": "${INSTANCE24_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S24N22",
+          "host": "${INSTANCE24_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S24N23",
+          "host": "${INSTANCE24_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S24N24",
+          "host": "${INSTANCE24_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S24N25",
+          "host": "${INSTANCE24_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S24N26",
+          "host": "${INSTANCE24_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S24N27",
+          "host": "${INSTANCE24_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S24N28",
+          "host": "${INSTANCE24_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S24N29",
+          "host": "${INSTANCE24_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S24N30",
+          "host": "${INSTANCE24_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S24N31",
+          "host": "${INSTANCE24_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S24N32",
+          "host": "${INSTANCE24_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S24N33",
+          "host": "${INSTANCE24_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S24N34",
+          "host": "${INSTANCE24_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S24N35",
+          "host": "${INSTANCE24_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S24N36",
+          "host": "${INSTANCE24_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S24N37",
+          "host": "${INSTANCE24_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S24N38",
+          "host": "${INSTANCE24_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S24N39",
+          "host": "${INSTANCE24_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S22N1",
+          "host": "${INSTANCE22_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U24",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE24_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-25/config.template.json
+++ b/deployment/aws/instance-25/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S25N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N40",
+          "host": "${INSTANCE25_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S25N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N2",
+          "host": "${INSTANCE25_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S25N3",
+          "host": "${INSTANCE25_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S25N4",
+          "host": "${INSTANCE25_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S25N5",
+          "host": "${INSTANCE25_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S25N6",
+          "host": "${INSTANCE25_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S25N7",
+          "host": "${INSTANCE25_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S25N8",
+          "host": "${INSTANCE25_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S25N9",
+          "host": "${INSTANCE25_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S25N10",
+          "host": "${INSTANCE25_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S25N11",
+          "host": "${INSTANCE25_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S25N12",
+          "host": "${INSTANCE25_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S25N13",
+          "host": "${INSTANCE25_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S25N14",
+          "host": "${INSTANCE25_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S25N15",
+          "host": "${INSTANCE25_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S25N16",
+          "host": "${INSTANCE25_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S25N17",
+          "host": "${INSTANCE25_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S25N18",
+          "host": "${INSTANCE25_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S25N19",
+          "host": "${INSTANCE25_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S25N20",
+          "host": "${INSTANCE25_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S25N21",
+          "host": "${INSTANCE25_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S25N22",
+          "host": "${INSTANCE25_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S25N23",
+          "host": "${INSTANCE25_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S25N24",
+          "host": "${INSTANCE25_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S25N25",
+          "host": "${INSTANCE25_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S25N26",
+          "host": "${INSTANCE25_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S25N27",
+          "host": "${INSTANCE25_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S25N28",
+          "host": "${INSTANCE25_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S25N29",
+          "host": "${INSTANCE25_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S25N30",
+          "host": "${INSTANCE25_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S25N31",
+          "host": "${INSTANCE25_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S25N32",
+          "host": "${INSTANCE25_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S25N33",
+          "host": "${INSTANCE25_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S25N34",
+          "host": "${INSTANCE25_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S25N35",
+          "host": "${INSTANCE25_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S25N36",
+          "host": "${INSTANCE25_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S25N37",
+          "host": "${INSTANCE25_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S25N38",
+          "host": "${INSTANCE25_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S25N39",
+          "host": "${INSTANCE25_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S23N1",
+          "host": "${INSTANCE23_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U25",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE25_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-26/config.template.json
+++ b/deployment/aws/instance-26/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S26N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N40",
+          "host": "${INSTANCE26_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S26N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N2",
+          "host": "${INSTANCE26_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S26N3",
+          "host": "${INSTANCE26_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S26N4",
+          "host": "${INSTANCE26_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S26N5",
+          "host": "${INSTANCE26_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S26N6",
+          "host": "${INSTANCE26_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S26N7",
+          "host": "${INSTANCE26_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S26N8",
+          "host": "${INSTANCE26_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S26N9",
+          "host": "${INSTANCE26_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S26N10",
+          "host": "${INSTANCE26_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S26N11",
+          "host": "${INSTANCE26_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S26N12",
+          "host": "${INSTANCE26_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S26N13",
+          "host": "${INSTANCE26_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S26N14",
+          "host": "${INSTANCE26_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S26N15",
+          "host": "${INSTANCE26_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S26N16",
+          "host": "${INSTANCE26_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S26N17",
+          "host": "${INSTANCE26_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S26N18",
+          "host": "${INSTANCE26_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S26N19",
+          "host": "${INSTANCE26_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S26N20",
+          "host": "${INSTANCE26_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S26N21",
+          "host": "${INSTANCE26_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S26N22",
+          "host": "${INSTANCE26_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S26N23",
+          "host": "${INSTANCE26_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S26N24",
+          "host": "${INSTANCE26_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S26N25",
+          "host": "${INSTANCE26_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S26N26",
+          "host": "${INSTANCE26_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S26N27",
+          "host": "${INSTANCE26_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S26N28",
+          "host": "${INSTANCE26_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S26N29",
+          "host": "${INSTANCE26_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S26N30",
+          "host": "${INSTANCE26_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S26N31",
+          "host": "${INSTANCE26_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S26N32",
+          "host": "${INSTANCE26_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S26N33",
+          "host": "${INSTANCE26_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S26N34",
+          "host": "${INSTANCE26_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S26N35",
+          "host": "${INSTANCE26_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S26N36",
+          "host": "${INSTANCE26_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S26N37",
+          "host": "${INSTANCE26_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S26N38",
+          "host": "${INSTANCE26_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S26N39",
+          "host": "${INSTANCE26_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S24N1",
+          "host": "${INSTANCE24_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U26",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE26_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-27/config.template.json
+++ b/deployment/aws/instance-27/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S27N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N40",
+          "host": "${INSTANCE27_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S27N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N2",
+          "host": "${INSTANCE27_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S27N3",
+          "host": "${INSTANCE27_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S27N4",
+          "host": "${INSTANCE27_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S27N5",
+          "host": "${INSTANCE27_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S27N6",
+          "host": "${INSTANCE27_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S27N7",
+          "host": "${INSTANCE27_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S27N8",
+          "host": "${INSTANCE27_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S27N9",
+          "host": "${INSTANCE27_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S27N10",
+          "host": "${INSTANCE27_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S27N11",
+          "host": "${INSTANCE27_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S27N12",
+          "host": "${INSTANCE27_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S27N13",
+          "host": "${INSTANCE27_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S27N14",
+          "host": "${INSTANCE27_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S27N15",
+          "host": "${INSTANCE27_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S27N16",
+          "host": "${INSTANCE27_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S27N17",
+          "host": "${INSTANCE27_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S27N18",
+          "host": "${INSTANCE27_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S27N19",
+          "host": "${INSTANCE27_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S27N20",
+          "host": "${INSTANCE27_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S27N21",
+          "host": "${INSTANCE27_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S27N22",
+          "host": "${INSTANCE27_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S27N23",
+          "host": "${INSTANCE27_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S27N24",
+          "host": "${INSTANCE27_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S27N25",
+          "host": "${INSTANCE27_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S27N26",
+          "host": "${INSTANCE27_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S27N27",
+          "host": "${INSTANCE27_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S27N28",
+          "host": "${INSTANCE27_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S27N29",
+          "host": "${INSTANCE27_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S27N30",
+          "host": "${INSTANCE27_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S27N31",
+          "host": "${INSTANCE27_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S27N32",
+          "host": "${INSTANCE27_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S27N33",
+          "host": "${INSTANCE27_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S27N34",
+          "host": "${INSTANCE27_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S27N35",
+          "host": "${INSTANCE27_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S27N36",
+          "host": "${INSTANCE27_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S27N37",
+          "host": "${INSTANCE27_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S27N38",
+          "host": "${INSTANCE27_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S27N39",
+          "host": "${INSTANCE27_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S25N1",
+          "host": "${INSTANCE25_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U27",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE27_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-28/config.template.json
+++ b/deployment/aws/instance-28/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S28N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N40",
+          "host": "${INSTANCE28_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S28N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N2",
+          "host": "${INSTANCE28_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S28N3",
+          "host": "${INSTANCE28_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S28N4",
+          "host": "${INSTANCE28_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S28N5",
+          "host": "${INSTANCE28_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S28N6",
+          "host": "${INSTANCE28_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S28N7",
+          "host": "${INSTANCE28_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S28N8",
+          "host": "${INSTANCE28_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S28N9",
+          "host": "${INSTANCE28_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S28N10",
+          "host": "${INSTANCE28_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S28N11",
+          "host": "${INSTANCE28_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S28N12",
+          "host": "${INSTANCE28_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S28N13",
+          "host": "${INSTANCE28_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S28N14",
+          "host": "${INSTANCE28_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S28N15",
+          "host": "${INSTANCE28_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S28N16",
+          "host": "${INSTANCE28_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S28N17",
+          "host": "${INSTANCE28_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S28N18",
+          "host": "${INSTANCE28_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S28N19",
+          "host": "${INSTANCE28_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S28N20",
+          "host": "${INSTANCE28_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S28N21",
+          "host": "${INSTANCE28_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S28N22",
+          "host": "${INSTANCE28_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S28N23",
+          "host": "${INSTANCE28_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S28N24",
+          "host": "${INSTANCE28_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S28N25",
+          "host": "${INSTANCE28_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S28N26",
+          "host": "${INSTANCE28_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S28N27",
+          "host": "${INSTANCE28_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S28N28",
+          "host": "${INSTANCE28_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S28N29",
+          "host": "${INSTANCE28_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S28N30",
+          "host": "${INSTANCE28_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S28N31",
+          "host": "${INSTANCE28_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S28N32",
+          "host": "${INSTANCE28_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S28N33",
+          "host": "${INSTANCE28_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S28N34",
+          "host": "${INSTANCE28_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S28N35",
+          "host": "${INSTANCE28_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S28N36",
+          "host": "${INSTANCE28_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S28N37",
+          "host": "${INSTANCE28_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S28N38",
+          "host": "${INSTANCE28_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S28N39",
+          "host": "${INSTANCE28_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S26N1",
+          "host": "${INSTANCE26_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U28",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE28_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-29/config.template.json
+++ b/deployment/aws/instance-29/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S29N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N40",
+          "host": "${INSTANCE29_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S29N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N2",
+          "host": "${INSTANCE29_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S29N3",
+          "host": "${INSTANCE29_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S29N4",
+          "host": "${INSTANCE29_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S29N5",
+          "host": "${INSTANCE29_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S29N6",
+          "host": "${INSTANCE29_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S29N7",
+          "host": "${INSTANCE29_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S29N8",
+          "host": "${INSTANCE29_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S29N9",
+          "host": "${INSTANCE29_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S29N10",
+          "host": "${INSTANCE29_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S29N11",
+          "host": "${INSTANCE29_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S29N12",
+          "host": "${INSTANCE29_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S29N13",
+          "host": "${INSTANCE29_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S29N14",
+          "host": "${INSTANCE29_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S29N15",
+          "host": "${INSTANCE29_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S29N16",
+          "host": "${INSTANCE29_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S29N17",
+          "host": "${INSTANCE29_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S29N18",
+          "host": "${INSTANCE29_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S29N19",
+          "host": "${INSTANCE29_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S29N20",
+          "host": "${INSTANCE29_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S29N21",
+          "host": "${INSTANCE29_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S29N22",
+          "host": "${INSTANCE29_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S29N23",
+          "host": "${INSTANCE29_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S29N24",
+          "host": "${INSTANCE29_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S29N25",
+          "host": "${INSTANCE29_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S29N26",
+          "host": "${INSTANCE29_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S29N27",
+          "host": "${INSTANCE29_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S29N28",
+          "host": "${INSTANCE29_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S29N29",
+          "host": "${INSTANCE29_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S29N30",
+          "host": "${INSTANCE29_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S29N31",
+          "host": "${INSTANCE29_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S29N32",
+          "host": "${INSTANCE29_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S29N33",
+          "host": "${INSTANCE29_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S29N34",
+          "host": "${INSTANCE29_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S29N35",
+          "host": "${INSTANCE29_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S29N36",
+          "host": "${INSTANCE29_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S29N37",
+          "host": "${INSTANCE29_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S29N38",
+          "host": "${INSTANCE29_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S29N39",
+          "host": "${INSTANCE29_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S27N1",
+          "host": "${INSTANCE27_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U29",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE29_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-30/config.template.json
+++ b/deployment/aws/instance-30/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S30N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N40",
+          "host": "${INSTANCE30_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S30N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N2",
+          "host": "${INSTANCE30_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S30N3",
+          "host": "${INSTANCE30_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S30N4",
+          "host": "${INSTANCE30_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S30N5",
+          "host": "${INSTANCE30_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S30N6",
+          "host": "${INSTANCE30_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S30N7",
+          "host": "${INSTANCE30_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S30N8",
+          "host": "${INSTANCE30_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S30N9",
+          "host": "${INSTANCE30_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S30N10",
+          "host": "${INSTANCE30_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S30N11",
+          "host": "${INSTANCE30_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S30N12",
+          "host": "${INSTANCE30_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S30N13",
+          "host": "${INSTANCE30_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S30N14",
+          "host": "${INSTANCE30_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S30N15",
+          "host": "${INSTANCE30_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S30N16",
+          "host": "${INSTANCE30_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S30N17",
+          "host": "${INSTANCE30_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S30N18",
+          "host": "${INSTANCE30_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S30N19",
+          "host": "${INSTANCE30_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S30N20",
+          "host": "${INSTANCE30_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S30N21",
+          "host": "${INSTANCE30_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S30N22",
+          "host": "${INSTANCE30_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S30N23",
+          "host": "${INSTANCE30_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S30N24",
+          "host": "${INSTANCE30_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S30N25",
+          "host": "${INSTANCE30_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S30N26",
+          "host": "${INSTANCE30_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S30N27",
+          "host": "${INSTANCE30_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S30N28",
+          "host": "${INSTANCE30_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S30N29",
+          "host": "${INSTANCE30_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S30N30",
+          "host": "${INSTANCE30_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S30N31",
+          "host": "${INSTANCE30_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S30N32",
+          "host": "${INSTANCE30_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S30N33",
+          "host": "${INSTANCE30_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S30N34",
+          "host": "${INSTANCE30_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S30N35",
+          "host": "${INSTANCE30_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S30N36",
+          "host": "${INSTANCE30_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S30N37",
+          "host": "${INSTANCE30_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S30N38",
+          "host": "${INSTANCE30_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S30N39",
+          "host": "${INSTANCE30_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S28N1",
+          "host": "${INSTANCE28_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U30",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE30_IP}:62000"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add JSON deployment templates for AWS instances 21 through 30
- ensure each instance defines 40 storage nodes with intra-instance and cross-instance peer topology
- include the corresponding user bootstrap entries for the new instances

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d906f37aac83279dd708abc97242cc