### PR TITLE
Add AWS configs for instances 31-40

### DIFF
--- a/deployment/aws/instance-31/config.template.json
+++ b/deployment/aws/instance-31/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S31N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N40",
+          "host": "${INSTANCE31_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S31N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N2",
+          "host": "${INSTANCE31_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S31N3",
+          "host": "${INSTANCE31_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S31N4",
+          "host": "${INSTANCE31_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S31N5",
+          "host": "${INSTANCE31_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S31N6",
+          "host": "${INSTANCE31_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S31N7",
+          "host": "${INSTANCE31_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S31N8",
+          "host": "${INSTANCE31_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S31N9",
+          "host": "${INSTANCE31_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S31N10",
+          "host": "${INSTANCE31_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S31N11",
+          "host": "${INSTANCE31_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S31N12",
+          "host": "${INSTANCE31_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S31N13",
+          "host": "${INSTANCE31_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S31N14",
+          "host": "${INSTANCE31_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S31N15",
+          "host": "${INSTANCE31_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S31N16",
+          "host": "${INSTANCE31_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S31N17",
+          "host": "${INSTANCE31_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S31N18",
+          "host": "${INSTANCE31_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S31N19",
+          "host": "${INSTANCE31_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S31N20",
+          "host": "${INSTANCE31_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S31N21",
+          "host": "${INSTANCE31_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S31N22",
+          "host": "${INSTANCE31_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S31N23",
+          "host": "${INSTANCE31_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S31N24",
+          "host": "${INSTANCE31_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S31N25",
+          "host": "${INSTANCE31_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S31N26",
+          "host": "${INSTANCE31_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S31N27",
+          "host": "${INSTANCE31_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S31N28",
+          "host": "${INSTANCE31_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S31N29",
+          "host": "${INSTANCE31_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S31N30",
+          "host": "${INSTANCE31_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S31N31",
+          "host": "${INSTANCE31_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S31N32",
+          "host": "${INSTANCE31_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S31N33",
+          "host": "${INSTANCE31_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S31N34",
+          "host": "${INSTANCE31_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S31N35",
+          "host": "${INSTANCE31_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S31N36",
+          "host": "${INSTANCE31_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S31N37",
+          "host": "${INSTANCE31_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S31N38",
+          "host": "${INSTANCE31_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S31N39",
+          "host": "${INSTANCE31_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S29N1",
+          "host": "${INSTANCE29_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U31",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE31_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-32/config.template.json
+++ b/deployment/aws/instance-32/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S32N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N40",
+          "host": "${INSTANCE32_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S32N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N2",
+          "host": "${INSTANCE32_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S32N3",
+          "host": "${INSTANCE32_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S32N4",
+          "host": "${INSTANCE32_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S32N5",
+          "host": "${INSTANCE32_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S32N6",
+          "host": "${INSTANCE32_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S32N7",
+          "host": "${INSTANCE32_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S32N8",
+          "host": "${INSTANCE32_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S32N9",
+          "host": "${INSTANCE32_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S32N10",
+          "host": "${INSTANCE32_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S32N11",
+          "host": "${INSTANCE32_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S32N12",
+          "host": "${INSTANCE32_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S32N13",
+          "host": "${INSTANCE32_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S32N14",
+          "host": "${INSTANCE32_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S32N15",
+          "host": "${INSTANCE32_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S32N16",
+          "host": "${INSTANCE32_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S32N17",
+          "host": "${INSTANCE32_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S32N18",
+          "host": "${INSTANCE32_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S32N19",
+          "host": "${INSTANCE32_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S32N20",
+          "host": "${INSTANCE32_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S32N21",
+          "host": "${INSTANCE32_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S32N22",
+          "host": "${INSTANCE32_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S32N23",
+          "host": "${INSTANCE32_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S32N24",
+          "host": "${INSTANCE32_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S32N25",
+          "host": "${INSTANCE32_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S32N26",
+          "host": "${INSTANCE32_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S32N27",
+          "host": "${INSTANCE32_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S32N28",
+          "host": "${INSTANCE32_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S32N29",
+          "host": "${INSTANCE32_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S32N30",
+          "host": "${INSTANCE32_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S32N31",
+          "host": "${INSTANCE32_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S32N32",
+          "host": "${INSTANCE32_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S32N33",
+          "host": "${INSTANCE32_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S32N34",
+          "host": "${INSTANCE32_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S32N35",
+          "host": "${INSTANCE32_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S32N36",
+          "host": "${INSTANCE32_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S32N37",
+          "host": "${INSTANCE32_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S32N38",
+          "host": "${INSTANCE32_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S32N39",
+          "host": "${INSTANCE32_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S30N1",
+          "host": "${INSTANCE30_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U32",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE32_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-33/config.template.json
+++ b/deployment/aws/instance-33/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S33N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N40",
+          "host": "${INSTANCE33_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S33N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N2",
+          "host": "${INSTANCE33_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S33N3",
+          "host": "${INSTANCE33_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S33N4",
+          "host": "${INSTANCE33_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S33N5",
+          "host": "${INSTANCE33_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S33N6",
+          "host": "${INSTANCE33_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S33N7",
+          "host": "${INSTANCE33_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S33N8",
+          "host": "${INSTANCE33_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S33N9",
+          "host": "${INSTANCE33_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S33N10",
+          "host": "${INSTANCE33_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S33N11",
+          "host": "${INSTANCE33_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S33N12",
+          "host": "${INSTANCE33_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S33N13",
+          "host": "${INSTANCE33_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S33N14",
+          "host": "${INSTANCE33_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S33N15",
+          "host": "${INSTANCE33_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S33N16",
+          "host": "${INSTANCE33_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S33N17",
+          "host": "${INSTANCE33_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S33N18",
+          "host": "${INSTANCE33_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S33N19",
+          "host": "${INSTANCE33_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S33N20",
+          "host": "${INSTANCE33_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S33N21",
+          "host": "${INSTANCE33_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S33N22",
+          "host": "${INSTANCE33_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S33N23",
+          "host": "${INSTANCE33_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S33N24",
+          "host": "${INSTANCE33_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S33N25",
+          "host": "${INSTANCE33_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S33N26",
+          "host": "${INSTANCE33_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S33N27",
+          "host": "${INSTANCE33_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S33N28",
+          "host": "${INSTANCE33_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S33N29",
+          "host": "${INSTANCE33_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S33N30",
+          "host": "${INSTANCE33_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S33N31",
+          "host": "${INSTANCE33_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S33N32",
+          "host": "${INSTANCE33_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S33N33",
+          "host": "${INSTANCE33_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S33N34",
+          "host": "${INSTANCE33_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S33N35",
+          "host": "${INSTANCE33_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S33N36",
+          "host": "${INSTANCE33_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S33N37",
+          "host": "${INSTANCE33_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S33N38",
+          "host": "${INSTANCE33_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S33N39",
+          "host": "${INSTANCE33_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S31N1",
+          "host": "${INSTANCE31_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U33",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE33_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-34/config.template.json
+++ b/deployment/aws/instance-34/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S34N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N40",
+          "host": "${INSTANCE34_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S34N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N2",
+          "host": "${INSTANCE34_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S34N3",
+          "host": "${INSTANCE34_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S34N4",
+          "host": "${INSTANCE34_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S34N5",
+          "host": "${INSTANCE34_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S34N6",
+          "host": "${INSTANCE34_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S34N7",
+          "host": "${INSTANCE34_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S34N8",
+          "host": "${INSTANCE34_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S34N9",
+          "host": "${INSTANCE34_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S34N10",
+          "host": "${INSTANCE34_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S34N11",
+          "host": "${INSTANCE34_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S34N12",
+          "host": "${INSTANCE34_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S34N13",
+          "host": "${INSTANCE34_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S34N14",
+          "host": "${INSTANCE34_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S34N15",
+          "host": "${INSTANCE34_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S34N16",
+          "host": "${INSTANCE34_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S34N17",
+          "host": "${INSTANCE34_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S34N18",
+          "host": "${INSTANCE34_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S34N19",
+          "host": "${INSTANCE34_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S34N20",
+          "host": "${INSTANCE34_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S34N21",
+          "host": "${INSTANCE34_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S34N22",
+          "host": "${INSTANCE34_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S34N23",
+          "host": "${INSTANCE34_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S34N24",
+          "host": "${INSTANCE34_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S34N25",
+          "host": "${INSTANCE34_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S34N26",
+          "host": "${INSTANCE34_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S34N27",
+          "host": "${INSTANCE34_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S34N28",
+          "host": "${INSTANCE34_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S34N29",
+          "host": "${INSTANCE34_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S34N30",
+          "host": "${INSTANCE34_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S34N31",
+          "host": "${INSTANCE34_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S34N32",
+          "host": "${INSTANCE34_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S34N33",
+          "host": "${INSTANCE34_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S34N34",
+          "host": "${INSTANCE34_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S34N35",
+          "host": "${INSTANCE34_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S34N36",
+          "host": "${INSTANCE34_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S34N37",
+          "host": "${INSTANCE34_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S34N38",
+          "host": "${INSTANCE34_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S34N39",
+          "host": "${INSTANCE34_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S32N1",
+          "host": "${INSTANCE32_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U34",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE34_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-35/config.template.json
+++ b/deployment/aws/instance-35/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S35N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N40",
+          "host": "${INSTANCE35_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S35N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N2",
+          "host": "${INSTANCE35_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S35N3",
+          "host": "${INSTANCE35_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S35N4",
+          "host": "${INSTANCE35_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S35N5",
+          "host": "${INSTANCE35_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S35N6",
+          "host": "${INSTANCE35_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S35N7",
+          "host": "${INSTANCE35_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S35N8",
+          "host": "${INSTANCE35_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S35N9",
+          "host": "${INSTANCE35_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S35N10",
+          "host": "${INSTANCE35_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S35N11",
+          "host": "${INSTANCE35_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S35N12",
+          "host": "${INSTANCE35_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S35N13",
+          "host": "${INSTANCE35_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S35N14",
+          "host": "${INSTANCE35_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S35N15",
+          "host": "${INSTANCE35_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S35N16",
+          "host": "${INSTANCE35_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S35N17",
+          "host": "${INSTANCE35_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S35N18",
+          "host": "${INSTANCE35_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S35N19",
+          "host": "${INSTANCE35_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S35N20",
+          "host": "${INSTANCE35_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S35N21",
+          "host": "${INSTANCE35_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S35N22",
+          "host": "${INSTANCE35_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S35N23",
+          "host": "${INSTANCE35_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S35N24",
+          "host": "${INSTANCE35_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S35N25",
+          "host": "${INSTANCE35_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S35N26",
+          "host": "${INSTANCE35_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S35N27",
+          "host": "${INSTANCE35_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S35N28",
+          "host": "${INSTANCE35_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S35N29",
+          "host": "${INSTANCE35_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S35N30",
+          "host": "${INSTANCE35_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S35N31",
+          "host": "${INSTANCE35_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S35N32",
+          "host": "${INSTANCE35_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S35N33",
+          "host": "${INSTANCE35_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S35N34",
+          "host": "${INSTANCE35_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S35N35",
+          "host": "${INSTANCE35_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S35N36",
+          "host": "${INSTANCE35_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S35N37",
+          "host": "${INSTANCE35_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S35N38",
+          "host": "${INSTANCE35_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S35N39",
+          "host": "${INSTANCE35_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S33N1",
+          "host": "${INSTANCE33_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U35",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE35_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-36/config.template.json
+++ b/deployment/aws/instance-36/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S36N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N40",
+          "host": "${INSTANCE36_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S36N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N2",
+          "host": "${INSTANCE36_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S36N3",
+          "host": "${INSTANCE36_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S36N4",
+          "host": "${INSTANCE36_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S36N5",
+          "host": "${INSTANCE36_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S36N6",
+          "host": "${INSTANCE36_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S36N7",
+          "host": "${INSTANCE36_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S36N8",
+          "host": "${INSTANCE36_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S36N9",
+          "host": "${INSTANCE36_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S36N10",
+          "host": "${INSTANCE36_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S36N11",
+          "host": "${INSTANCE36_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S36N12",
+          "host": "${INSTANCE36_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S36N13",
+          "host": "${INSTANCE36_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S36N14",
+          "host": "${INSTANCE36_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S36N15",
+          "host": "${INSTANCE36_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S36N16",
+          "host": "${INSTANCE36_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S36N17",
+          "host": "${INSTANCE36_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S36N18",
+          "host": "${INSTANCE36_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S36N19",
+          "host": "${INSTANCE36_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S36N20",
+          "host": "${INSTANCE36_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S36N21",
+          "host": "${INSTANCE36_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S36N22",
+          "host": "${INSTANCE36_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S36N23",
+          "host": "${INSTANCE36_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S36N24",
+          "host": "${INSTANCE36_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S36N25",
+          "host": "${INSTANCE36_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S36N26",
+          "host": "${INSTANCE36_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S36N27",
+          "host": "${INSTANCE36_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S36N28",
+          "host": "${INSTANCE36_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S36N29",
+          "host": "${INSTANCE36_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S36N30",
+          "host": "${INSTANCE36_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S36N31",
+          "host": "${INSTANCE36_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S36N32",
+          "host": "${INSTANCE36_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S36N33",
+          "host": "${INSTANCE36_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S36N34",
+          "host": "${INSTANCE36_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S36N35",
+          "host": "${INSTANCE36_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S36N36",
+          "host": "${INSTANCE36_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S36N37",
+          "host": "${INSTANCE36_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S36N38",
+          "host": "${INSTANCE36_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S36N39",
+          "host": "${INSTANCE36_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S34N1",
+          "host": "${INSTANCE34_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U36",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE36_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-37/config.template.json
+++ b/deployment/aws/instance-37/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S37N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N40",
+          "host": "${INSTANCE37_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S37N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N2",
+          "host": "${INSTANCE37_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S37N3",
+          "host": "${INSTANCE37_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S37N4",
+          "host": "${INSTANCE37_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S37N5",
+          "host": "${INSTANCE37_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S37N6",
+          "host": "${INSTANCE37_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S37N7",
+          "host": "${INSTANCE37_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S37N8",
+          "host": "${INSTANCE37_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S37N9",
+          "host": "${INSTANCE37_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S37N10",
+          "host": "${INSTANCE37_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S37N11",
+          "host": "${INSTANCE37_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S37N12",
+          "host": "${INSTANCE37_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S37N13",
+          "host": "${INSTANCE37_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S37N14",
+          "host": "${INSTANCE37_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S37N15",
+          "host": "${INSTANCE37_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S37N16",
+          "host": "${INSTANCE37_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S37N17",
+          "host": "${INSTANCE37_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S37N18",
+          "host": "${INSTANCE37_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S37N19",
+          "host": "${INSTANCE37_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S37N20",
+          "host": "${INSTANCE37_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S37N21",
+          "host": "${INSTANCE37_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S37N22",
+          "host": "${INSTANCE37_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S37N23",
+          "host": "${INSTANCE37_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S37N24",
+          "host": "${INSTANCE37_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S37N25",
+          "host": "${INSTANCE37_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S37N26",
+          "host": "${INSTANCE37_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S37N27",
+          "host": "${INSTANCE37_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S37N28",
+          "host": "${INSTANCE37_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S37N29",
+          "host": "${INSTANCE37_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S37N30",
+          "host": "${INSTANCE37_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S37N31",
+          "host": "${INSTANCE37_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S37N32",
+          "host": "${INSTANCE37_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S37N33",
+          "host": "${INSTANCE37_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S37N34",
+          "host": "${INSTANCE37_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S37N35",
+          "host": "${INSTANCE37_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S37N36",
+          "host": "${INSTANCE37_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S37N37",
+          "host": "${INSTANCE37_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S37N38",
+          "host": "${INSTANCE37_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S37N39",
+          "host": "${INSTANCE37_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S35N1",
+          "host": "${INSTANCE35_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U37",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE37_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-38/config.template.json
+++ b/deployment/aws/instance-38/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S38N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N40",
+          "host": "${INSTANCE38_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S38N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N2",
+          "host": "${INSTANCE38_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S38N3",
+          "host": "${INSTANCE38_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S38N4",
+          "host": "${INSTANCE38_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S38N5",
+          "host": "${INSTANCE38_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S38N6",
+          "host": "${INSTANCE38_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S38N7",
+          "host": "${INSTANCE38_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S38N8",
+          "host": "${INSTANCE38_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S38N9",
+          "host": "${INSTANCE38_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S38N10",
+          "host": "${INSTANCE38_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S38N11",
+          "host": "${INSTANCE38_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S38N12",
+          "host": "${INSTANCE38_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S38N13",
+          "host": "${INSTANCE38_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S38N14",
+          "host": "${INSTANCE38_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S38N15",
+          "host": "${INSTANCE38_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S38N16",
+          "host": "${INSTANCE38_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S38N17",
+          "host": "${INSTANCE38_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S38N18",
+          "host": "${INSTANCE38_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S38N19",
+          "host": "${INSTANCE38_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S38N20",
+          "host": "${INSTANCE38_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S38N21",
+          "host": "${INSTANCE38_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S38N22",
+          "host": "${INSTANCE38_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S38N23",
+          "host": "${INSTANCE38_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S38N24",
+          "host": "${INSTANCE38_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S38N25",
+          "host": "${INSTANCE38_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S38N26",
+          "host": "${INSTANCE38_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S38N27",
+          "host": "${INSTANCE38_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S38N28",
+          "host": "${INSTANCE38_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S38N29",
+          "host": "${INSTANCE38_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S38N30",
+          "host": "${INSTANCE38_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S38N31",
+          "host": "${INSTANCE38_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S38N32",
+          "host": "${INSTANCE38_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S38N33",
+          "host": "${INSTANCE38_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S38N34",
+          "host": "${INSTANCE38_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S38N35",
+          "host": "${INSTANCE38_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S38N36",
+          "host": "${INSTANCE38_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S38N37",
+          "host": "${INSTANCE38_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S38N38",
+          "host": "${INSTANCE38_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S38N39",
+          "host": "${INSTANCE38_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S36N1",
+          "host": "${INSTANCE36_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U38",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE38_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-39/config.template.json
+++ b/deployment/aws/instance-39/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S39N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N40",
+          "host": "${INSTANCE39_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S39N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N2",
+          "host": "${INSTANCE39_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S39N3",
+          "host": "${INSTANCE39_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S39N4",
+          "host": "${INSTANCE39_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S39N5",
+          "host": "${INSTANCE39_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S39N6",
+          "host": "${INSTANCE39_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S39N7",
+          "host": "${INSTANCE39_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S39N8",
+          "host": "${INSTANCE39_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S39N9",
+          "host": "${INSTANCE39_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S39N10",
+          "host": "${INSTANCE39_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S39N11",
+          "host": "${INSTANCE39_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S39N12",
+          "host": "${INSTANCE39_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S39N13",
+          "host": "${INSTANCE39_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S39N14",
+          "host": "${INSTANCE39_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S39N15",
+          "host": "${INSTANCE39_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S39N16",
+          "host": "${INSTANCE39_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S39N17",
+          "host": "${INSTANCE39_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S39N18",
+          "host": "${INSTANCE39_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S39N19",
+          "host": "${INSTANCE39_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S39N20",
+          "host": "${INSTANCE39_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S39N21",
+          "host": "${INSTANCE39_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S39N22",
+          "host": "${INSTANCE39_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S39N23",
+          "host": "${INSTANCE39_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S39N24",
+          "host": "${INSTANCE39_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S39N25",
+          "host": "${INSTANCE39_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S39N26",
+          "host": "${INSTANCE39_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S39N27",
+          "host": "${INSTANCE39_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S39N28",
+          "host": "${INSTANCE39_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S39N29",
+          "host": "${INSTANCE39_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S39N30",
+          "host": "${INSTANCE39_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S39N31",
+          "host": "${INSTANCE39_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S39N32",
+          "host": "${INSTANCE39_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S39N33",
+          "host": "${INSTANCE39_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S39N34",
+          "host": "${INSTANCE39_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S39N35",
+          "host": "${INSTANCE39_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S39N36",
+          "host": "${INSTANCE39_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S39N37",
+          "host": "${INSTANCE39_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S39N38",
+          "host": "${INSTANCE39_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S39N39",
+          "host": "${INSTANCE39_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S37N1",
+          "host": "${INSTANCE37_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U39",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE39_IP}:62000"
+    }
+  ]
+}

--- a/deployment/aws/instance-40/config.template.json
+++ b/deployment/aws/instance-40/config.template.json
@@ -1,0 +1,8578 @@
+{
+  "chunk_size": 1024,
+  "min_file_kb": 16,
+  "max_file_kb": 64,
+  "bobtail_k": 3,
+  "default_storage_kb": 8192,
+  "mining_difficulty_hex": "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff",
+  "nodes": [
+    {
+      "node_id": "S40N1",
+      "host": "0.0.0.0",
+      "port": 62000,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N2",
+      "host": "0.0.0.0",
+      "port": 62001,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N3",
+      "host": "0.0.0.0",
+      "port": 62002,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N4",
+      "host": "0.0.0.0",
+      "port": 62003,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N5",
+      "host": "0.0.0.0",
+      "port": 62004,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N6",
+      "host": "0.0.0.0",
+      "port": 62005,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N7",
+      "host": "0.0.0.0",
+      "port": 62006,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N8",
+      "host": "0.0.0.0",
+      "port": 62007,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N9",
+      "host": "0.0.0.0",
+      "port": 62008,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N10",
+      "host": "0.0.0.0",
+      "port": 62009,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N11",
+      "host": "0.0.0.0",
+      "port": 62010,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N12",
+      "host": "0.0.0.0",
+      "port": 62011,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N13",
+      "host": "0.0.0.0",
+      "port": 62012,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N14",
+      "host": "0.0.0.0",
+      "port": 62013,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N15",
+      "host": "0.0.0.0",
+      "port": 62014,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N16",
+      "host": "0.0.0.0",
+      "port": 62015,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N17",
+      "host": "0.0.0.0",
+      "port": 62016,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N18",
+      "host": "0.0.0.0",
+      "port": 62017,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N19",
+      "host": "0.0.0.0",
+      "port": 62018,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N20",
+      "host": "0.0.0.0",
+      "port": 62019,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N21",
+      "host": "0.0.0.0",
+      "port": 62020,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N22",
+      "host": "0.0.0.0",
+      "port": 62021,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N23",
+      "host": "0.0.0.0",
+      "port": 62022,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N24",
+      "host": "0.0.0.0",
+      "port": 62023,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N25",
+      "host": "0.0.0.0",
+      "port": 62024,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N26",
+      "host": "0.0.0.0",
+      "port": 62025,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N27",
+      "host": "0.0.0.0",
+      "port": 62026,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N28",
+      "host": "0.0.0.0",
+      "port": 62027,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N29",
+      "host": "0.0.0.0",
+      "port": 62028,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N30",
+      "host": "0.0.0.0",
+      "port": 62029,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N31",
+      "host": "0.0.0.0",
+      "port": 62030,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N32",
+      "host": "0.0.0.0",
+      "port": 62031,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N33",
+      "host": "0.0.0.0",
+      "port": 62032,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N34",
+      "host": "0.0.0.0",
+      "port": 62033,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N35",
+      "host": "0.0.0.0",
+      "port": 62034,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N36",
+      "host": "0.0.0.0",
+      "port": 62035,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N37",
+      "host": "0.0.0.0",
+      "port": 62036,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N38",
+      "host": "0.0.0.0",
+      "port": 62037,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N39",
+      "host": "0.0.0.0",
+      "port": 62038,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N40",
+          "host": "${INSTANCE40_IP}",
+          "port": 62039
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    },
+    {
+      "node_id": "S40N40",
+      "host": "0.0.0.0",
+      "port": 62039,
+      "storage_kb": 8192,
+      "bootstrap": "none",
+      "peers": [
+        {
+          "node_id": "S40N1",
+          "host": "${INSTANCE40_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S40N2",
+          "host": "${INSTANCE40_IP}",
+          "port": 62001
+        },
+        {
+          "node_id": "S40N3",
+          "host": "${INSTANCE40_IP}",
+          "port": 62002
+        },
+        {
+          "node_id": "S40N4",
+          "host": "${INSTANCE40_IP}",
+          "port": 62003
+        },
+        {
+          "node_id": "S40N5",
+          "host": "${INSTANCE40_IP}",
+          "port": 62004
+        },
+        {
+          "node_id": "S40N6",
+          "host": "${INSTANCE40_IP}",
+          "port": 62005
+        },
+        {
+          "node_id": "S40N7",
+          "host": "${INSTANCE40_IP}",
+          "port": 62006
+        },
+        {
+          "node_id": "S40N8",
+          "host": "${INSTANCE40_IP}",
+          "port": 62007
+        },
+        {
+          "node_id": "S40N9",
+          "host": "${INSTANCE40_IP}",
+          "port": 62008
+        },
+        {
+          "node_id": "S40N10",
+          "host": "${INSTANCE40_IP}",
+          "port": 62009
+        },
+        {
+          "node_id": "S40N11",
+          "host": "${INSTANCE40_IP}",
+          "port": 62010
+        },
+        {
+          "node_id": "S40N12",
+          "host": "${INSTANCE40_IP}",
+          "port": 62011
+        },
+        {
+          "node_id": "S40N13",
+          "host": "${INSTANCE40_IP}",
+          "port": 62012
+        },
+        {
+          "node_id": "S40N14",
+          "host": "${INSTANCE40_IP}",
+          "port": 62013
+        },
+        {
+          "node_id": "S40N15",
+          "host": "${INSTANCE40_IP}",
+          "port": 62014
+        },
+        {
+          "node_id": "S40N16",
+          "host": "${INSTANCE40_IP}",
+          "port": 62015
+        },
+        {
+          "node_id": "S40N17",
+          "host": "${INSTANCE40_IP}",
+          "port": 62016
+        },
+        {
+          "node_id": "S40N18",
+          "host": "${INSTANCE40_IP}",
+          "port": 62017
+        },
+        {
+          "node_id": "S40N19",
+          "host": "${INSTANCE40_IP}",
+          "port": 62018
+        },
+        {
+          "node_id": "S40N20",
+          "host": "${INSTANCE40_IP}",
+          "port": 62019
+        },
+        {
+          "node_id": "S40N21",
+          "host": "${INSTANCE40_IP}",
+          "port": 62020
+        },
+        {
+          "node_id": "S40N22",
+          "host": "${INSTANCE40_IP}",
+          "port": 62021
+        },
+        {
+          "node_id": "S40N23",
+          "host": "${INSTANCE40_IP}",
+          "port": 62022
+        },
+        {
+          "node_id": "S40N24",
+          "host": "${INSTANCE40_IP}",
+          "port": 62023
+        },
+        {
+          "node_id": "S40N25",
+          "host": "${INSTANCE40_IP}",
+          "port": 62024
+        },
+        {
+          "node_id": "S40N26",
+          "host": "${INSTANCE40_IP}",
+          "port": 62025
+        },
+        {
+          "node_id": "S40N27",
+          "host": "${INSTANCE40_IP}",
+          "port": 62026
+        },
+        {
+          "node_id": "S40N28",
+          "host": "${INSTANCE40_IP}",
+          "port": 62027
+        },
+        {
+          "node_id": "S40N29",
+          "host": "${INSTANCE40_IP}",
+          "port": 62028
+        },
+        {
+          "node_id": "S40N30",
+          "host": "${INSTANCE40_IP}",
+          "port": 62029
+        },
+        {
+          "node_id": "S40N31",
+          "host": "${INSTANCE40_IP}",
+          "port": 62030
+        },
+        {
+          "node_id": "S40N32",
+          "host": "${INSTANCE40_IP}",
+          "port": 62031
+        },
+        {
+          "node_id": "S40N33",
+          "host": "${INSTANCE40_IP}",
+          "port": 62032
+        },
+        {
+          "node_id": "S40N34",
+          "host": "${INSTANCE40_IP}",
+          "port": 62033
+        },
+        {
+          "node_id": "S40N35",
+          "host": "${INSTANCE40_IP}",
+          "port": 62034
+        },
+        {
+          "node_id": "S40N36",
+          "host": "${INSTANCE40_IP}",
+          "port": 62035
+        },
+        {
+          "node_id": "S40N37",
+          "host": "${INSTANCE40_IP}",
+          "port": 62036
+        },
+        {
+          "node_id": "S40N38",
+          "host": "${INSTANCE40_IP}",
+          "port": 62037
+        },
+        {
+          "node_id": "S40N39",
+          "host": "${INSTANCE40_IP}",
+          "port": 62038
+        },
+        {
+          "node_id": "S38N1",
+          "host": "${INSTANCE38_IP}",
+          "port": 62000
+        },
+        {
+          "node_id": "S39N1",
+          "host": "${INSTANCE39_IP}",
+          "port": 62000
+        }
+      ]
+    }
+  ],
+  "users": [
+    {
+      "user_id": "U40",
+      "host": "0.0.0.0",
+      "port": 62100,
+      "bootstrap": "${INSTANCE40_IP}:62000"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add config templates for AWS instances 31 through 40 mirroring the existing 40-node layout
- ensure each instance connects to the prior two instance leaders and exposes a user bootstrap endpoint

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d908f89ba48327a34147b0f5868c22